### PR TITLE
chore: remove no-op pinDigests packageRule

### DIFF
--- a/default.json
+++ b/default.json
@@ -58,10 +58,6 @@
       "rangeStrategy": "bump"
     },
     {
-      "matchDepTypes": ["packageManager", "github-actions"],
-      "pinDigests": true
-    },
-    {
       "description": "Rank packageRules from least to most important as Renovate allows lower rules to override higher ones. For more details, see: https://docs.renovatebot.com/configuration-options/#packagerules:~:text=Order%20your%20packageRules",
       "groupName": "nozomiishii",
       "minimumReleaseAge": null,


### PR DESCRIPTION
## Summary

`pinDigests: true` を指定していた packageRule が実際には何にも適用されない no-op だったため削除。

```diff
-    {
-      "matchDepTypes": ["packageManager", "github-actions"],
-      "pinDigests": true
-    },
```

## 背景

reusable workflow (`uses: owner/repo/path@SHA # v1.0.0`) の追従を Renovate が標準サポートしているか調査する過程で、当該ルールが no-op であることが判明した。

- 公式ドキュメントより `pinDigests` は **Docker images と GitHub Actions 専用**。npm datasource (pnpm/packageManager) には適用されない
- `NpmDatasource` は `getDigest` 未実装のため、指定しても問い合わせる先がない
- `github-actions` という depType は存在しない (実 depType は `action` / `docker` / `github-runner` など)

## 影響なし

github-actions の digest pin は `extends: ["config:best-practices"]` 内の `helpers:pinGitHubActionDigests` が担うため、削除後も挙動は変わらない。

実挙動とも一致:

- `package.json` の `"packageManager": "pnpm@10.33.0"` に digest は付いていない (Corepack 形式の digest は別機能で現状未サポート)
- 過去の Renovate PR (pnpm v10.26.1〜v10.33.0 の update series) も digest 付加なし

## 検証

- `pnpm validate` (`renovate-config-validator --strict default.json`) ✅
- `pnpm format` ✅
