### PR TITLE
chore: remove redundant default overrides

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,8 +3,6 @@
 
   "extends": ["config:best-practices", ":semanticCommitTypeAll(chore)", ":semanticCommitScopeDisabled"],
 
-  "dependencyDashboard": true,
-
   "labels": ["dependencies"],
   "timezone": "Asia/Tokyo",
   "prConcurrentLimit": 0,
@@ -13,14 +11,9 @@
   "semanticCommits": "enabled",
   "rangeStrategy": "pin",
   "separateMultipleMajor": true,
-  "platformAutomerge": true,
   "automerge": true,
   "major": {
     "automerge": false
-  },
-
-  "vulnerabilityAlerts": {
-    "enabled": true
   },
 
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
## Summary

Renovate のデフォルト値や preset に既に含まれている設定の明示指定を削除。挙動は一切変わらず config の見通しだけ良くなる。

## 削除した 3 項目

### 1. `dependencyDashboard: true`

`extends: ["config:best-practices"]` → `config:recommended` → `:dependencyDashboard` がすでに `dependencyDashboard: true` をセット済み (`lib/config/presets/internal/default.preset.ts`)。

### 2. `platformAutomerge: true`

Renovate のデフォルト値が `true` (`lib/config/options/index.ts` で `default: true`)。どの preset も上書きしていない。

### 3. `vulnerabilityAlerts: { enabled: true }`

`vulnerabilityAlerts` のデフォルトオブジェクトに `enabled` キーは含まれず、実装側 (`lib/workers/repository/init/vulnerability.ts`) の判定は:

```ts
if (input.vulnerabilityAlerts.enabled === false) { return input; }
```

**明示的に `false` の時のみ無効化**する仕様。未指定 = 有効なので `enabled: true` は何も変えない。

## 影響

- Renovate の次回実行以降も挙動は完全に同一
- この config を `extends: ["github>nozomiishii/renovate"]` で参照する全 downstream repo への影響もゼロ

## 検証

- `pnpm validate` (`renovate-config-validator --strict default.json`) ✅
- `pnpm format` ✅

## 精査対象外（= 意図的な上書きとして残した設定）

| 設定 | デフォルト | 判定 |
| --- | --- | --- |
| `labels: ["dependencies"]` | なし | 必要 |
| `timezone: "Asia/Tokyo"` | `"Etc/UTC"` | schedule の基準時間として必要 |
| `prConcurrentLimit: 0` / `prHourlyLimit: 0` | 10 / 2 | 意図的に rate limit 解除 |
| `semanticCommits: "enabled"` | `"auto"` | 予測可能にするため明示 |
| `rangeStrategy: "pin"` | `"auto"` | best-practices の `:pinDevDependencies` より強い上書き |
| `separateMultipleMajor: true` | `false` | 意図的 |
| `automerge: true` + `major: { automerge: false }` | false / - | 意図的ペア |
| `osvVulnerabilityAlerts: true` | `false` | 意図的 |
| `rebaseWhen: "conflicted"` | `"auto"` | 意図的 |
| `nix: { enabled: true }` | `false` | 意図的 |
| `git-submodules: { enabled: true }` | `false` | 意図的 |
| `postUpdateOptions: ["pnpmDedupe", "npmDedupe"]` | `[]` | 意図的 |

## 関連

#602 (別件で no-op packageRule を削除する PR) とは独立した変更。
