### PR TITLE
chore: annotate default.json with inline JSONC comments

### DIFF
--- a/.vscode/settings.example.jsonc
+++ b/.vscode/settings.example.jsonc
@@ -1,0 +1,8 @@
+{
+  // default.json は Renovate preset で JSONC コメント (// や /* */) を含んでいる。
+  // Renovate のパーサは問題なく解釈するが、VS Code は .json 拡張子だと strict JSON 扱いで
+  // 赤線 (syntax error) を出してしまうため、JSONC として関連付ける。
+  "files.associations": {
+    "default.json": "jsonc"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -59,30 +59,7 @@ done
 
 ## Main
 
-[default.json](./default.json)
-
-## Preference
-
-- `"$schema": "https://docs.renovatebot.com/renovate-schema.json"`
-  - 補完出してくれる
-
-- `extends`
-  - デフォルトでついてくる`config:base`の必要部分を抽出
-
-- `labels`
-  - 自動で作られるPRにラベルがつく
-
-- `"prConcurrentLimit": 0`
-  - Limit系は0で設定すると無制限って意味になる
-
-- `stabilityDays`
-  - 安定猶予期間を設定。ここで指定した日数が経ってからオートマージされる
-
-- `separateMultipleMajor`
-  - メジャーバージョンのPRは個別に出す
-
-- `rangeStrategy`
-  - バージョンの上げ方。"pin"にすると^や~がつかない固定バージョンになる
+[default.json](./default.json) に全設定を集約。各設定の意図はインラインコメントを参照。
 
 ## tips
 

--- a/default.json
+++ b/default.json
@@ -1,25 +1,48 @@
 {
+  // エディタ (VS Code 等) で補完・検証を効かせるための JSON Schema 参照
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
+  // 採用 preset:
+  // - config:best-practices: Renovate 推奨一式 (config:recommended + docker/action digest pin +
+  //   :pinDevDependencies + security:minimumReleaseAgeNpm (npm 3 日待ち) + :maintainLockFilesWeekly)
+  // - :semanticCommitTypeAll(chore): 全 PR を chore: prefix に統一
+  //   (recommended の :semanticPrefixFixDepsChoreOthers の fix/chore 分けを上書き)
+  // - :semanticCommitScopeDisabled: semantic commit の scope 部分を付けない
   "extends": ["config:best-practices", ":semanticCommitTypeAll(chore)", ":semanticCommitScopeDisabled"],
 
+  // 自動生成 PR に付けるラベル
   "labels": ["dependencies"],
+
+  // schedule の基準タイムゾーン (デフォルト UTC)
   "timezone": "Asia/Tokyo",
+
+  // 0 = 無制限。デフォルトの 10 並列 / 2 per hour 制限を外して一気に流す
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
 
+  // semantic commit を明示的に on (デフォルト "auto" は history から推測する挙動)
   "semanticCommits": "enabled",
+
+  // ^ / ~ を付けず固定バージョンに揃える (デフォルト "auto")
+  // peerDependencies だけは下の packageRules で "bump" に上書き
   "rangeStrategy": "pin",
+
+  // メジャー毎に別 PR を作る (例: v3→v4 と v4→v5 を分離)
   "separateMultipleMajor": true,
+
+  // minor / patch は自動マージ。major は下の上書きで無効化
   "automerge": true,
   "major": {
     "automerge": false
   },
 
+  // GitHub Security Advisory に加え osv.dev の脆弱性 DB も監視 (デフォルト false)
   "osvVulnerabilityAlerts": true,
 
+  // base branch に新 commit が来ても conflict が発生するまで rebase しない (ノイズ削減)
   "rebaseWhen": "conflicted",
 
+  // flake.nix の inputs 更新を有効化 (デフォルト false)
   "nix": {
     "enabled": true
   },
@@ -30,6 +53,8 @@
       "matchPackageNames": ["renovate"],
       "schedule": ["before 9am on Monday"]
     },
+
+    // 関連パッケージのグルーピング (個別 PR 乱立を防ぐ)
     {
       "groupName": "figma-export",
       "matchPackageNames": ["/figma-export/"]
@@ -42,14 +67,23 @@
       "groupName": "textlint",
       "matchPackageNames": ["/textlint/"]
     },
+
+    // download / upload は片側だけ上がると CI が壊れがちなので一緒に
     {
       "matchPackageNames": ["actions/download-artifact", "actions/upload-artifact"],
       "groupName": "artifact"
     },
+
+    // peerDeps はライブラリ互換性維持のため pin せず範囲を bump
     {
       "matchDepTypes": ["peerDependencies"],
       "rangeStrategy": "bump"
     },
+
+    // 自前 (nozomiishii/*) パッケージは security:minimumReleaseAgeNpm が
+    // 課す 3 日待ちを解除して即時取り込み。
+    // packageRules は後方優先なので必ず最後に配置
+    // https://docs.renovatebot.com/configuration-options/#packagerules
     {
       "description": "Rank packageRules from least to most important as Renovate allows lower rules to override higher ones. For more details, see: https://docs.renovatebot.com/configuration-options/#packagerules:~:text=Order%20your%20packageRules",
       "groupName": "nozomiishii",
@@ -58,13 +92,17 @@
     }
   ],
 
+  // 更新後に lockfile を自動 dedupe (pnpm dedupe / npm dedupe)
   "postUpdateOptions": ["pnpmDedupe", "npmDedupe"],
 
+  // git submodule の ref 更新を追従対象にする (デフォルト false)
   "git-submodules": {
     "enabled": true
   },
 
+  // 公式 manager が拾えない箇所の追従用 custom manager
   "customManagers": [
+    // pnpm-workspace.yaml の useNodeVersion を node-version datasource で追従
     {
       "customType": "regex",
       "managerFilePatterns": ["/^pnpm-workspace\\.ya?ml$/"],

--- a/default.json
+++ b/default.json
@@ -48,8 +48,8 @@
   },
 
   "packageRules": [
+    // renovate 本体の更新は頻度が高いので週 1 に絞る
     {
-      "description": "Limit renovate package updates to a weekly schedule",
       "matchPackageNames": ["renovate"],
       "schedule": ["before 9am on Monday"]
     },
@@ -81,11 +81,11 @@
     },
 
     // 自前 (nozomiishii/*) パッケージは security:minimumReleaseAgeNpm が
-    // 課す 3 日待ちを解除して即時取り込み。
-    // packageRules は後方優先なので必ず最後に配置
+    // 課す 3 日待ちを解除して即時取り込みする。
+    // packageRules は後方のルールほど優先されるので必ず最後に配置
     // https://docs.renovatebot.com/configuration-options/#packagerules
     {
-      "description": "Rank packageRules from least to most important as Renovate allows lower rules to override higher ones. For more details, see: https://docs.renovatebot.com/configuration-options/#packagerules:~:text=Order%20your%20packageRules",
+      "description": "Opt nozomiishii/* packages out of the minimumReleaseAge delay",
       "groupName": "nozomiishii",
       "minimumReleaseAge": null,
       "matchPackageNames": ["/nozomiishii/"]

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "format": "pnpm prettier . --check",
     "format:fix": "pnpm prettier . --write",
+    "postinstall": "postinstall",
     "prettier": "prettier --ignore-unknown",
     "validate": "renovate-config-validator --strict default.json"
   },
@@ -30,6 +31,7 @@
     "@nozomiishii/commitlint-config": "0.0.10",
     "@nozomiishii/lefthook-config": "0.3.6",
     "@nozomiishii/markdownlint-cli2-config": "0.3.5",
+    "@nozomiishii/postinstall": "0.0.7",
     "@nozomiishii/prettier-config": "0.7.2",
     "lefthook": "2.1.5",
     "renovate": "43.110.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@nozomiishii/markdownlint-cli2-config':
         specifier: 0.3.5
         version: 0.3.5
+      '@nozomiishii/postinstall':
+        specifier: 0.0.7
+        version: 0.0.7
       '@nozomiishii/prettier-config':
         specifier: 0.7.2
         version: 0.7.2
@@ -383,6 +386,10 @@ packages:
 
   '@nozomiishii/markdownlint-cli2-config@0.3.5':
     resolution: {integrity: sha512-5YZjv3i0MMexmGpa4L6spTHSUGCAAl541brOoqJaG6m9TEXIZW1zZ4Dd2cKl3Egmes5zv/vmfrc6JcRyVmR3qQ==}
+    hasBin: true
+
+  '@nozomiishii/postinstall@0.0.7':
+    resolution: {integrity: sha512-p7tVsV9RS83PSfStoL5Z12+T0H5NLlWhUV4A9owccfKwiusiWQeNSzPtreaAxKhXpHv13omZ6BRHHmFXVT+bVQ==}
     hasBin: true
 
   '@nozomiishii/prettier-config@0.7.2':
@@ -1544,6 +1551,11 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  figlet@1.11.0:
+    resolution: {integrity: sha512-EEx3OS/l2bFqcUNN2NM9FPJp8vAMrgbCxsbl2hbcJNNxOEwVe3mEzrhan7TbJQViZa8mMqhihlbCaqD+LyYKTQ==}
+    engines: {node: '>= 17.0.0'}
+    hasBin: true
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -3051,6 +3063,11 @@ packages:
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
+  zx@8.8.5:
+    resolution: {integrity: sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==}
+    engines: {node: '>= 12.17.0'}
+    hasBin: true
+
 snapshots:
 
   '@arcanis/slice-ansi@1.1.1':
@@ -4027,6 +4044,11 @@ snapshots:
       markdownlint-cli2: 0.20.0
     transitivePeerDependencies:
       - supports-color
+
+  '@nozomiishii/postinstall@0.0.7':
+    dependencies:
+      figlet: 1.11.0
+      zx: 8.8.5
 
   '@nozomiishii/prettier-config@0.7.2':
     dependencies:
@@ -5352,6 +5374,10 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  figlet@1.11.0:
+    dependencies:
+      commander: 14.0.3
 
   file-uri-to-path@1.0.0:
     optional: true
@@ -7261,3 +7287,5 @@ snapshots:
   zod@4.3.6: {}
 
   zwitch@2.0.4: {}
+
+  zx@8.8.5: {}


### PR DESCRIPTION
## Summary

`default.json` の各設定に意図を表す JSONC コメントをインラインで付与。README の Preference セクションが古くなっていたのを「コメントが config と同じ場所にある」形式に移行する。

## 変更点

### `default.json` — インラインコメントで網羅注釈

- `$schema` / `extends` / top-level 設定 / `packageRules` / `customManagers` の全 key に `//` コメントで why を付与
- 例: なぜ `rangeStrategy: "pin"` か、なぜ peerDeps だけ `bump` に上書きか、なぜ `minimumReleaseAge: null` が自前パッケージだけ必要か、等

実挙動は変わらず (コメント追加のみ)。

### VS Code 対応 — `.vscode/settings.example.jsonc` + postinstall

- `.vscode/` は `.gitignore` で `settings.json` を除外したままにしつつ、**template となる `settings.example.jsonc` を commit**
- `@nozomiishii/postinstall@0.0.7` の `setupVSCode` が `pnpm install` 時に `settings.example.jsonc` → `settings.json` を自動コピー
- 中身は `default.json` を JSONC 扱いさせる file association だけ:
  ```jsonc
  { "files.associations": { "default.json": "jsonc" } }
  ```

### `package.json`

- `scripts.postinstall: "postinstall"` 追加
- `devDependencies`: `@nozomiishii/postinstall@0.0.7` 追加

## Renovate 側の互換性

ソースコード (`lib/util/common.ts` → `parseJson` → `parseJsonWithFallback`) を確認済み:

- `default.json` 本体は内部で `parseJsonc` 経由でパースされる (コメント OK)
- `renovate-config-validator --strict default.json` ✅ PASS
- consumer 側の `extends: ["github>nozomiishii/renovate"]` の書き方は変わらず

## 検討した他の方針 (棄却)

| 案 | 棄却理由 |
| --- | --- |
| `.json5` サブプリセット分割 (bjw-s / home-operations 方式) | ファイル分割コストが現状規模では過剰。コメント粒度も広く取れる |
| `default.template.json5` → ビルドで `default.json` 生成 (SpotOnInc 方式) | ビルドステップ追加でメンテ負担増 |
| README.md の Preference 更新 | README と `default.json` の 2 箇所同期コストが残る |

主要な renovate-config repo 20 件調査 (hatena, teppeis, cybozu, bjw-s, unjs, home-operations, aquaproj 他) では **JSONC コメント in `default.json` の採用例は 0 件** だったが、公式ドキュメントで明示的に推奨されている書式 (https://docs.renovatebot.com/config-presets/) なので、実装上問題なく採用できる。

## 検証

- `pnpm validate` (`renovate-config-validator --strict`) ✅
- `pnpm format` (`prettier --check`) ✅
- `pnpm install` で `.vscode/settings.json` が自動生成されることを確認
- pre-commit / commit-msg / pre-push hook 全 pass
