### PR TITLE
chore: ignore .pnpm-store directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ lefthook-local.yaml
 **/CLAUDE.local.md
 **/.claude/worktrees/
 **/.claude/debug/
+
+# pnpm
+.pnpm-store


### PR DESCRIPTION
## 概要

- `.pnpm-store` ディレクトリを `.gitignore` に追加

## 背景

pnpm のローカルストア (`.pnpm-store`) がプロジェクトルートに生成された場合に Git 追跡対象とならないようにする。
