### PR TITLE
chore: bump shared workflows to v1.1.1 and simplify actionlint permissions

### DIFF
--- a/.github/workflows/_actionlint.yaml
+++ b/.github/workflows/_actionlint.yaml
@@ -11,9 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   actionlint:
-    permissions:
-      contents: read
-      pull-requests: read
     uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1


### PR DESCRIPTION
PR #613 merge 時点ではまだ v1.1.0 だったので `_pull-request.yaml` / `_secretlint.yaml` を v1.1.1 に bump。加えて `_actionlint.yaml` の permissions を job-level から workflow-level に移し、他 2 ファイルと揃える（挙動は [dev#2828 実験](https://github.com/nozomiishii/dev/pull/2828) で同等確認済み）。