### PR TITLE
feat: extend minimumReleaseAge delay to all datasources

### DIFF
--- a/default.json
+++ b/default.json
@@ -86,8 +86,11 @@
     // 同じ 3 日待ちを npm 以外 (GitHub Actions, Docker, submodule, nix 等) にも
     // 拡張し、supply chain 防御の穴を塞ぐ。
     // 値は Renovate 公式判断 (security:minimumReleaseAgeNpm の 3 日) を踏襲。
-    // 7 日への延長は marginal benefit が約 13pp のみで、CVE パッチ取り込み遅延と
-    // 釣り合わない。
+    // 7 日への延長は marginal benefit が約 13pp のみで、通常更新が 4 日長く
+    // 遅れるコストと釣り合わない。
+    // (CVE パッチは vulnerabilityAlerts のデフォルト minimumReleaseAge=null +
+    //  prCreation=immediate で即時取り込みされ、ここで設定する値の影響を
+    //  受けないため、dev velocity の議論は通常更新にのみ関わる)
     // 詳細: https://github.com/nozomiishii/renovate/issues/624
     {
       "description": "Extend the 3-day minimumReleaseAge delay to all datasources, not just npm",

--- a/default.json
+++ b/default.json
@@ -36,6 +36,15 @@
     "automerge": false
   },
 
+  // security:minimumReleaseAgeNpm は npm datasource にしか 3 日待ちを課さない。
+  // 同じ 3 日待ちを全 datasource に拡張する。
+  // 値は Renovate 公式判断 (security:minimumReleaseAgeNpm の 3 日) を踏襲。
+  // lockFileMaintenance / pin / replacement は Renovate 側で release age が
+  // wire されていないため自動的に即時取り込み:
+  //   https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account
+  // CVE パッチも vulnerabilityAlerts がバイパスするため影響なし。
+  "minimumReleaseAge": "3 days",
+
   // GitHub Security Advisory に加え osv.dev の脆弱性 DB も監視 (デフォルト false)
   "osvVulnerabilityAlerts": true,
 
@@ -80,30 +89,7 @@
       "rangeStrategy": "bump"
     },
 
-    // security:minimumReleaseAgeNpm は npm datasource にしか 3 日待ちを課さない。
-    // 2024-2026 の npm インシデントを見ると、攻撃版の検出・unpublish は
-    // 大半が 72 時間以内に完了している (Socket / Aikido / Phylum による自動監視)。
-    // 同じ 3 日待ちを npm 以外 (GitHub Actions, Docker, submodule, nix 等) にも
-    // 拡張し、supply chain 防御の穴を塞ぐ。
-    // 値は Renovate 公式判断 (security:minimumReleaseAgeNpm の 3 日) を踏襲。
-    // (CVE パッチは vulnerabilityAlerts のデフォルト minimumReleaseAge=null +
-    //  prCreation=immediate で即時取り込みされ、ここで設定する値の影響を受けない)
-    {
-      "description": "Extend the 3-day minimumReleaseAge delay to all datasources, not just npm",
-      "matchPackageNames": ["*"],
-      "minimumReleaseAge": "3 days"
-    },
-    // security:minimumReleaseAgeNpm の 3 つの例外 (lockFileMaintenance /
-    // replacement / pin) を全 datasource で再適用する。
-    // Renovate 自体がこれらの path で release age を参照していないため、
-    // 待たせても実効がなく、むしろ lockfile 更新を止めてしまう。
-    {
-      "description": "Preserve the exceptions security:minimumReleaseAgeNpm defines for lockFileMaintenance / replacement / pin across all datasources",
-      "matchUpdateTypes": ["lockFileMaintenance", "replacement", "pin"],
-      "minimumReleaseAge": null
-    },
-
-    // 自前 (nozomiishii/*) パッケージは security:minimumReleaseAgeNpm が
+    // 自前 (nozomiishii/*) パッケージは top-level minimumReleaseAge が
     // 課す 3 日待ちを解除して即時取り込みする。
     // packageRules は後方のルールほど優先されるので必ず最後に配置
     // https://docs.renovatebot.com/configuration-options/#packagerules

--- a/default.json
+++ b/default.json
@@ -80,6 +80,30 @@
       "rangeStrategy": "bump"
     },
 
+    // security:minimumReleaseAgeNpm は npm datasource にしか 3 日待ちを課さない。
+    // 2024-2026 の npm インシデントを見ると、攻撃版の検出・unpublish は
+    // 大半が 72 時間以内に完了している (Socket / Aikido / Phylum による自動監視)。
+    // 同じ 3 日待ちを npm 以外 (GitHub Actions, Docker, submodule, nix 等) にも
+    // 拡張し、supply chain 防御の穴を塞ぐ。
+    // 値は Renovate 公式判断 (security:minimumReleaseAgeNpm の 3 日) を踏襲。
+    // 7 日への延長は marginal benefit が約 13pp のみで、CVE パッチ取り込み遅延と
+    // 釣り合わない。
+    // 詳細: https://github.com/nozomiishii/renovate/issues/624
+    {
+      "description": "Extend the 3-day minimumReleaseAge delay to all datasources, not just npm",
+      "matchPackageNames": ["*"],
+      "minimumReleaseAge": "3 days"
+    },
+    // security:minimumReleaseAgeNpm の 3 つの例外 (lockFileMaintenance /
+    // replacement / pin) を全 datasource で再適用する。
+    // Renovate 自体がこれらの path で release age を参照していないため、
+    // 待たせても実効がなく、むしろ lockfile 更新を止めてしまう。
+    {
+      "description": "Preserve the exceptions security:minimumReleaseAgeNpm defines for lockFileMaintenance / replacement / pin across all datasources",
+      "matchUpdateTypes": ["lockFileMaintenance", "replacement", "pin"],
+      "minimumReleaseAge": null
+    },
+
     // 自前 (nozomiishii/*) パッケージは security:minimumReleaseAgeNpm が
     // 課す 3 日待ちを解除して即時取り込みする。
     // packageRules は後方のルールほど優先されるので必ず最後に配置

--- a/default.json
+++ b/default.json
@@ -86,12 +86,8 @@
     // 同じ 3 日待ちを npm 以外 (GitHub Actions, Docker, submodule, nix 等) にも
     // 拡張し、supply chain 防御の穴を塞ぐ。
     // 値は Renovate 公式判断 (security:minimumReleaseAgeNpm の 3 日) を踏襲。
-    // 7 日への延長は marginal benefit が約 13pp のみで、通常更新が 4 日長く
-    // 遅れるコストと釣り合わない。
     // (CVE パッチは vulnerabilityAlerts のデフォルト minimumReleaseAge=null +
-    //  prCreation=immediate で即時取り込みされ、ここで設定する値の影響を
-    //  受けないため、dev velocity の議論は通常更新にのみ関わる)
-    // 詳細: https://github.com/nozomiishii/renovate/issues/624
+    //  prCreation=immediate で即時取り込みされ、ここで設定する値の影響を受けない)
     {
       "description": "Extend the 3-day minimumReleaseAge delay to all datasources, not just npm",
       "matchPackageNames": ["*"],


### PR DESCRIPTION
## Summary

`config:best-practices` が導入する `security:minimumReleaseAgeNpm` は **npm datasource にしか 3 日待ちを課さない**。GitHub Actions / Docker / submodule / nix などは現状 release 直後でも auto-merge されうるため、ここを塞ぐのが本 PR の目的。

Refs: #624

## 変更内容

`default.json` の top-level に `"minimumReleaseAge": "3 days"` を 1 行追加するだけ。値は Renovate 公式判断（`security:minimumReleaseAgeNpm` の 3 日）を踏襲。

```json
"minimumReleaseAge": "3 days"
```

このリポでは 2023-02 〜 2025-11 の間、同じ形で top-level に設定していた。2025-11 の commit で「v42 からデフォルトで入るから」と削除したが、実際に v42 で入ったのは npm 限定の `security:minimumReleaseAgeNpm` のみで、他の datasource はガードされていなかった。本 PR はその穴を塞ぐ。

## なぜ例外ルールを書かなくて良いか

[公式ドキュメントの update type サポート表](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account) より:

| Update Type | `minimumReleaseAge` Supports? |
|---|---|
| `major` / `minor` / `patch` | ✅ |
| `pin` | ❌ [Not yet supported (#40288)](https://github.com/renovatebot/renovate/issues/40288) |
| `pinDigest` | ❌ [#40288](https://github.com/renovatebot/renovate/issues/40288) |
| `lockFileMaintenance` | ❌ "Not possible, as we delegate to the package manager" |
| `replacement` | ❌ [#39400](https://github.com/renovatebot/renovate/issues/39400) |
| `digest` / `bump` / `rollback` / `lockfileUpdate` | ❌ |

つまり `lockFileMaintenance` / `pin` / `replacement` などは Renovate 側で release age を wire していないため、top-level に 3 日設定を書いても自動的にバイパスされる。例外ルール (`minimumReleaseAge: null`) を明示する必要はない。

過去 2 年 9 ヶ月の運用実績（2023-02 〜 2025-11 に top-level で同じ設定）でも `lockFileMaintenance` 週次 PR / `rangeStrategy: "pin"` 由来の pin 更新は問題なく動作していた。

## CVE パッチは本 PR の影響を受けない

Renovate の `vulnerabilityAlerts` デフォルト設定（`minimumReleaseAge: null` + `prCreation: 'immediate'` + `commitMessageSuffix: '[SECURITY]'`）が `mergeable: true` で top-level を上書きする。GHSA / osv.dev で検知された CVE パッチは **この 3 日設定に関係なく即時 PR 作成 → auto-merge** される。

参考: [security] suffix 付き PR の例 https://github.com/nozomiishii/dev/pull/2785

## 影響範囲

この repo は shared config なので、`@nozomiishii/renovate` を `extends` している全リポジトリに反映される:

- **npm**: 現状 3 日 → 変更なし（top-level と preset で同じ値）
- **github-tags / github-releases** (GitHub Actions): 現状 0 日 → **3 日に延長**
- **docker**: 現状 0 日 → **3 日に延長**
- **nix / git-submodules / node-version 等**: 現状 0 日 → **3 日に延長**
- **CVE 起点の更新**: 全 datasource で影響なし (`vulnerabilityAlerts` がバイパス)
- **nozomiishii/* パッケージ**: 既存の例外ルール（`minimumReleaseAge: null`）が後勝ちで即時取り込み継続

## Test plan

- [x] `pnpm validate` pass（pre-commit hook で確認済み）
- [x] `pnpm format` pass
- [ ] マージ後、実リポジトリで GitHub Actions 更新の PR が 3 日待機になることを確認
- [ ] nozomiishii/* パッケージの更新が引き続き即時で入ることを確認
- [ ] CVE 起点の PR（[security] suffix 付き）が引き続き即時で入ることを確認

## 参考

- Issue: #624（経緯と調査データ）
- [Renovate Minimum Release Age Docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/)
