### PR TITLE
chore: enforce semver-tag digest pin for GitHub Actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,13 +2,21 @@
   // エディタ (VS Code 等) で補完・検証を効かせるための JSON Schema 参照
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  // 採用 preset:
-  // - config:best-practices: Renovate 推奨一式 (config:recommended + docker/action digest pin +
-  //   :pinDevDependencies + security:minimumReleaseAgeNpm (npm 3 日待ち) + :maintainLockFilesWeekly)
-  // - :semanticCommitTypeAll(chore): 全 PR を chore: prefix に統一
-  //   (recommended の :semanticPrefixFixDepsChoreOthers の fix/chore 分けを上書き)
-  // - :semanticCommitScopeDisabled: semantic commit の scope 部分を付けない
-  "extends": ["config:best-practices", ":semanticCommitTypeAll(chore)", ":semanticCommitScopeDisabled"],
+  "extends": [
+    // Renovate 推奨一式 (config:recommended + docker/action digest pin +
+    // :pinDevDependencies + security:minimumReleaseAgeNpm (npm 3 日待ち) + :maintainLockFilesWeekly)
+    "config:best-practices",
+
+    // GitHub Action の pin を semver tag (`@v16.6.0`) 前提に切り替える。
+    // major-only tag (`@v16`) は追跡対象から外れ、tag 再ポイントでの差し替え攻撃を防ぐ。
+    "helpers:pinGitHubActionDigestsToSemver",
+
+    // 全 PR を chore: prefix に統一 (recommended の :semanticPrefixFixDepsChoreOthers の fix/chore 分けを上書き)
+    ":semanticCommitTypeAll(chore)",
+
+    // semantic commit の scope 部分を付けない
+    ":semanticCommitScopeDisabled"
+  ],
 
   // 自動生成 PR に付けるラベル
   "labels": ["dependencies"],


### PR DESCRIPTION
## 背景

`chromaui/action` 向けに Renovate が `v16` → `v16` で digest のみ差し替える PR を auto-merge した ([nozomiishii/dev#2832](https://github.com/nozomiishii/dev/pull/2832))。

調査の結果、これは **`v16` タグが v16.5.0 → v16.6.0 へ再ポイント** された結果の差し替えだった（chromaui 側が `v16` を movable major tag として運用している）。

`helpers:pinGitHubActionDigests` による SHA pin + `# v16` コメント運用では:

- chromaui 側で `v16` タグが force-push された場合、中身検証なしに auto-merge で取り込まれる可能性がある
- 実質的には `uses: foo/bar@v16` 直指定と変わらず、pin による保護がほぼ効かない
- PR の見た目が `v16` → `v16` で、実態（v16.5.0 → v16.6.0 の minor update）が読み取れず紛らわしい

## 変更内容

`extends` に [`helpers:pinGitHubActionDigestsToSemver`](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/helpers.preset.ts) を追加。

この preset は `extractVersion` / `versioning` を上書きして、**semver tag (`@v16.6.0`) のみを追跡対象にする**:

- `uses: foo/bar@v16.6.0` → `@<SHA> # v16.6.0` の形で pin される
- `uses: foo/bar@v16`（major-only）→ 追跡対象から外れ、digest 差し替え PR は出なくなる
- 新バージョンリリース時は `v16.6.0 → v16.7.0` の semver PR になる

semver tag は慣習的に再ポイントされないため、「同じタグのまま中身を差し替えられる」攻撃面が構造的に消える。

また、extends 内コメントを各 preset の直上に移動してまとめ読みしやすくした。

## 利用側で必要な移行作業

本 PR 単体では既存の `@<SHA> # v16` pin は自動で置換されない。配信先リポジトリで workflow の `uses:` コメントを `# v16.x.y` のように semver に書き換えるか、`@v16.x.y` semver tag に切り替える必要がある。SHA はそのままでよい。

## テスト

- `pnpm format` — 整形差分なし
- `pnpm validate` — `renovate-config-validator --strict` 通過
- lefthook pre-commit / commit-msg 通過
