### PR TITLE
fix: forbid BREAKING CHANGE footer for ops-only changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,7 @@ pnpm validate
 
 - 変更は基本的に `default.json` を中心に行い、更新後は `pnpm validate` で strict に検証する。
 - JSON の編集後は `pnpm format` / `pnpm prettier` を必ず反映させる。
+
+## リリース・Conventional Commits
+
+- `BREAKING CHANGE:` フッターと `feat!:` / `fix!:` の `!` 修飾は、**リリースされるパッケージ・公開アセットの互換性を破る変更にのみ**使用する。CI / workflows / branch protection / リポジトリ運用上の変更には使わない。これらの注意事項は PR 本文に記述する（release-please など自動リリースツールが major / minor バンプを誤って行い、CHANGELOG に `⚠ BREAKING CHANGES` セクションを誤生成するのを防ぐため。実例: 2026-04-25 にこのリポジトリ群で `chore: migrate reusable workflows to v3.0.0` PR が誤って BREAKING CHANGE として記録された）。


### PR DESCRIPTION
## 概要

`BREAKING CHANGE:` フッターを CI / workflows などリポジトリ運用上の変更に使用してしまうことを防ぐルールを CLAUDE.md に追記する（または新規作成する）。

## 背景

PR `chore: migrate reusable workflows to v3.0.0` で commit message に書いた `BREAKING CHANGE:` フッターが、release-please の `bump-minor-pre-major: true` 設定下で minor bump (0.x → 0.(x+1).0) のシグナルとして拾われた。

- 実害発生: nozomiishii/git-harvest で 0.1.20 → 0.2.0 と誤判定 (release PR #88、close 済み)。修正後は 0.1.21 (#110)。
- このリポジトリ含む他 9 リポジトリは release-please 未使用のため version bump への実害は出なかったが、git history に誤った BREAKING CHANGE フッターが残り、将来の release-please / changelog ツール導入時にノイズになる。今回 history rewrite で除去済み。

再発防止として、`BREAKING CHANGE:` フッターは「リリースされるパッケージ / 公開アセットの互換性を破る変更にのみ」使用するルールを明文化する。

## 関連

- 元事故 PR: nozomiishii/git-harvest#106
- 誤った release PR: nozomiishii/git-harvest#88（close 済み）
- 修正後の release PR: nozomiishii/git-harvest#110（0.1.21）
- git-harvest の同等 docs PR: nozomiishii/git-harvest#111
