### PR TITLE
feat: track Makefile _VERSION variables via official preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,7 +15,12 @@
     ":semanticCommitTypeAll(chore)",
 
     // semantic commit の scope 部分を付けない
-    ":semanticCommitScopeDisabled"
+    ":semanticCommitScopeDisabled",
+
+    // Makefile / GNUMakefile / *.mk の `# renovate: ...` annotation 付き `_VERSION` 変数を追従。
+    // 公式 preset (https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions)。
+    // Docker via Makefile pattern (Terraform エコシステム lint tools 等) で使用。
+    "customManagers:makefileVersions"
   ],
 
   // 自動生成 PR に付けるラベル


### PR DESCRIPTION
## Summary

公式 preset `customManagers:makefileVersions` を `extends` に追加。Makefile / GNUMakefile / *.mk 内の `# renovate:` annotation 付き `*_VERSION` 変数を Renovate が自動追跡するようになる。

## Background

`nozomiishii/infra` で **Docker via Makefile** パターン (TFLint / Trivy 等の lint tool を Docker 経由で実行、image tag を Makefile で pin) を採用予定。Renovate 公式 preset を継承することで、自作 regex custom manager を書かずに済む。

参考: 公式 preset 一覧 https://docs.renovatebot.com/presets-customManagers/

## Test plan

- [ ] この PR マージ後、`extends: ["github>nozomiishii/renovate"]` を継承する repo (例: `nozomiishii/infra`) で `customManagers:makefileVersions` preset が自動的に有効化される
- [ ] `nozomiishii/infra` の Makefile 内 `# renovate: datasource=docker depName=...` annotation 付き `*_VERSION` 変数に対し、Renovate が更新 PR を作成する (infra repo の関連 PR マージ後に実証)
