### PR TITLE
chore: opt git-harvest and pm out of minimumReleaseAge delay

### DIFF
--- a/default.json
+++ b/default.json
@@ -104,13 +104,14 @@
 
     // 自前 (nozomiishii/*) パッケージは top-level minimumReleaseAge が
     // 課す 3 日待ちを解除して即時取り込みする。
+    // git-harvest / pm は scope なしで公開している自前パッケージなので明示列挙。
     // packageRules は後方のルールほど優先されるので必ず最後に配置
     // https://docs.renovatebot.com/configuration-options/#packagerules
     {
-      "description": "Opt nozomiishii/* packages out of the minimumReleaseAge delay",
+      "description": "Opt nozomiishii self-managed packages out of the minimumReleaseAge delay",
       "groupName": "nozomiishii",
       "minimumReleaseAge": null,
-      "matchPackageNames": ["/nozomiishii/"]
+      "matchPackageNames": ["/nozomiishii/", "git-harvest", "pm"]
     }
   ],
 


### PR DESCRIPTION
## Summary

- 自前で管理している `git-harvest` / `pm` パッケージを `minimumReleaseAge` の 3 日待ちの対象外に追加
- 既存の `/nozomiishii/` regex は package 名に "nozomiishii" を含むものしかマッチしないため、scope なしで配布している `git-harvest` / `pm` は明示列挙が必要
- `pm` は 2 文字で regex 化すると誤爆リスクが高いので exact-match で追加

## Test plan

- [x] `pnpm validate` がパス
- [x] `pnpm format` がパス
