### PR TITLE
chore: trim redundant command sections from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,22 +2,6 @@
 
 このリポジトリで Claude Code (claude.ai/code) が作業する際のガイドラインです。
 
-## よく使うコマンド
-
-```sh
-# Prettier check
-pnpm format
-
-# Prettier format
-pnpm format:fix
-
-# Prettier (write)
-pnpm prettier
-
-# Renovate config validation
-pnpm validate
-```
-
 ## Git・GitHub 運用ルール
 
 - PR タイトルは英語 semantic 形式で、CI の semantic pull request チェックに従う。詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。


### PR DESCRIPTION
## Summary

`CLAUDE.md` から package.json / Makefile を読めば自明な「よく使うコマンド」セクションを削除し、ドキュメントの冗長性を低減する。

## 動機

`package.json` scripts や `Makefile` に書かれている内容を `CLAUDE.md` に重複して保持すると、片方の更新時にもう一方が drift し、AI / 人間ともに「コマンドの正本がどこか」が曖昧になる。正本を一本化するため、`CLAUDE.md` 側からはそれらを削除する。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていない
- [ ] 残されたセクションの内容に変更が無い
