### PR TITLE
chore: disable platformAutomerge to gate on all CI checks

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,6 +49,12 @@
     "automerge": false
   },
 
+  // GitHub native auto-merge は branch ruleset の required に登録された check しか待たないので、
+  // false にして Renovate worker 側で PR の全 status check / check run を gate にする。
+  // 代償: マージは次回 Renovate run まで遅延。
+  // https://docs.renovatebot.com/key-concepts/automerge/
+  "platformAutomerge": false,
+
   // security:minimumReleaseAgeNpm は npm datasource にしか 3 日待ちを課さない。
   // 同じ 3 日待ちを全 datasource に拡張する。
   // 値は Renovate 公式判断 (security:minimumReleaseAgeNpm の 3 日) を踏襲。


### PR DESCRIPTION
## 背景

[nozomiishii/dev PR #2875](https://github.com/nozomiishii/dev/pull/2875) で `Apps Home CI / static` が FAIL したまま Renovate が auto-merge してしまった。

原因は GitHub native auto-merge の仕様で、branch ruleset の required status checks に登録されたチェックしか待たないため。required 未登録の `static` ジョブの結果は無視され、required 3つが揃った瞬間にマージされた。

| 時刻 (UTC) | 出来事 |
|---|---|
| 22:33:55 | Renovate が auto-merge を有効化 |
| 22:34:08 | `static` ジョブ開始 |
| **22:34:15** | **マージ実行** |
| 22:34:59 | `static` ジョブが FAILURE で完了 |

## 変更

`platformAutomerge: false` を追加。Renovate worker 側でマージ判定する挙動に切り替える。

```diff
+  // GitHub native auto-merge は branch ruleset の required に登録された check しか待たないので、
+  // false にして Renovate worker 側で PR の全 status check / check run を gate にする。
+  // 代償: マージは次回 Renovate run まで遅延。
+  // https://docs.renovatebot.com/key-concepts/automerge/
+  "platformAutomerge": false,
```

## 効果

- PR の **全** status check / check run（required 登録の有無に関係なく）が green でないとマージしない
- required 一覧の追加メンテが不要になる（CI ジョブを増やしても自動的に gate になる）
- Renovate maintainer 自身も [renovatebot/renovate#16964](https://github.com/renovatebot/renovate/issues/16964) で「native auto-merge は failed status check と一緒にマージされうる」と認めている

## トレードオフ

- マージは次回 Renovate run まで遅延（schedule 次第で数十分）
- 即時マージ性が必要なケースには向かない（このリポジトリでは問題ない判断）

## 検証

- [x] `pnpm validate` (renovate-config-validator --strict) pass
- [x] `pnpm format` (prettier --check) pass
- [x] `commitlint` pass
