### PR TITLE
chore: trim derivable sections from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,11 @@
 
 ## アーキテクチャ概要
 
-`renovate` は Renovate Bot の共有設定パッケージです。
-
-- `default.json`: 主設定（`extends` や best practices を組み合わせている）
-- `.github/workflows/`: CI（format / validate / actionlint / secretlint / PR title check 等）
-- `bin/cli.sh`: npm/pnpm 経由で `npx -y @nozomiishii/renovate@latest` を実行するための CLI
+`renovate` は Renovate Bot の共有設定パッケージです。エントリポイントは `default.json`（`extends` や best practices を組み合わせた主設定）。
 
 ## 重要なパターン
 
 - 変更は基本的に `default.json` を中心に行い、更新後は `pnpm validate` で strict に検証する。
-- JSON の編集後は `pnpm format` / `pnpm prettier` を必ず反映させる。
 
 ## リリース・Conventional Commits
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` の追加トリム第 2 弾。先行 PR でコマンドリストを削った後、見直して **「ファイル一覧 / ディレクトリ列挙 / format-lint コマンドの再記述」** など、`ls` / `package.json` / `Makefile` / `.github/workflows/` を読めば自明な記述をさらに削除する。

## 変更内容（repo によって異なる）

- 「アーキテクチャ概要」配下の主要ディレクトリ列挙
- 「重要なパターン」内の "format / lint コマンドを使え" 系の箇条書き
- workflow ファイル列挙（`.github/workflows/` を読めば自明）
- ファイル名と短い説明だけのリスト

## 動機

`package.json` scripts / `Makefile` / ファイル一覧を `CLAUDE.md` に重複して保持すると drift する。WHY や非自明な制約は残し、それ以外は正本（コード・スクリプト・設定）に一本化する。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていない
- [ ] WHY (理由) を含む記述は残っている
