### PR TITLE
chore: drop important-patterns section from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,6 @@
 
 `renovate` は Renovate Bot の共有設定パッケージです。エントリポイントは `default.json`（`extends` や best practices を組み合わせた主設定）。
 
-## 重要なパターン
-
-- 変更は基本的に `default.json` を中心に行い、更新後は `pnpm validate` で strict に検証する。
-
 ## リリース・Conventional Commits
 
 - `BREAKING CHANGE:` フッターと `feat!:` / `fix!:` の `!` 修飾は、**リリースされるパッケージ・公開アセットの互換性を破る変更にのみ**使用する。CI / workflows / branch protection / リポジトリ運用上の変更には使わない。これらの注意事項は PR 本文に記述する（release-please など自動リリースツールが major / minor バンプを誤って行い、CHANGELOG に `⚠ BREAKING CHANGES` セクションを誤生成するのを防ぐため。実例: 2026-04-25 にこのリポジトリ群で `chore: migrate reusable workflows to v3.0.0` PR が誤って BREAKING CHANGE として記録された）。


### PR DESCRIPTION
## Summary

- `## 重要なパターン` セクションを `CLAUDE.md` から削除した
- 唯一残っていた `pnpm validate` ルールは [`lefthook.yaml`](lefthook.yaml) の `pre-commit` ジョブ `validate-renovate`（`default.json` 変更時のみ実行）で既に強制されているため、ドキュメント側に重複して書く必要がなくなった

## Test plan

- [x] `pnpm validate` が `default.json` 変更時に lefthook pre-commit から走ることを確認
- [x] commit 時に lefthook が `validate-renovate (skip) no matching staged files` でスキップ動作することを確認（CLAUDE.md だけの変更なので skip されるのが正しい）
