### PR TITLE
chore: skip stability-days check for lockFileMaintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -64,6 +64,19 @@
   // CVE パッチも vulnerabilityAlerts がバイパスするため影響なし。
   "minimumReleaseAge": "3 days",
 
+  // lockFileMaintenance は minimumReleaseAge を enforce しない仕様だが、グローバル設定がある以上
+  // `renovate/stability-days` status check は永遠 PENDING で post される。
+  // platformAutomerge: false の worker は PR 全 status を gate にするため、この check のせいで
+  // lockFileMaintenance PR の automerge が恒久 block されてしまう。
+  // statusCheckNames を null override して該当 PR では check 自体を post させず、他 CI 通過後に
+  // worker が merge できるようにする。
+  // https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account
+  "lockFileMaintenance": {
+    "statusCheckNames": {
+      "minimumReleaseAge": null
+    }
+  },
+
   // GitHub Security Advisory に加え osv.dev の脆弱性 DB も監視 (デフォルト false)
   "osvVulnerabilityAlerts": true,
 

--- a/default.json
+++ b/default.json
@@ -55,22 +55,16 @@
   // https://docs.renovatebot.com/key-concepts/automerge/
   "platformAutomerge": false,
 
-  // security:minimumReleaseAgeNpm は npm datasource にしか 3 日待ちを課さない。
-  // 同じ 3 日待ちを全 datasource に拡張する。
-  // 値は Renovate 公式判断 (security:minimumReleaseAgeNpm の 3 日) を踏襲。
-  // lockFileMaintenance / pin / replacement は Renovate 側で release age が
-  // wire されていないため自動的に即時取り込み:
-  //   https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account
-  // CVE パッチも vulnerabilityAlerts がバイパスするため影響なし。
+  // security:minimumReleaseAgeNpm の 3 日待ちを全 datasource に拡張する。値は公式判断 (3 日) を踏襲。
+  // enforce 対象は major/minor/patch のみ。lockFileMaintenance や pin/replacement 等は対象外
+  // (ただし lockFileMaintenance だけは stability-days を post してくるため下記で抑止)。
+  // CVE パッチは vulnerabilityAlerts がバイパスするため影響なし。
+  // https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account
   "minimumReleaseAge": "3 days",
 
-  // lockFileMaintenance は minimumReleaseAge を enforce しない仕様だが、グローバル設定がある以上
-  // `renovate/stability-days` status check は永遠 PENDING で post される。
-  // platformAutomerge: false の worker は PR 全 status を gate にするため、この check のせいで
-  // lockFileMaintenance PR の automerge が恒久 block されてしまう。
-  // statusCheckNames を null override して該当 PR では check 自体を post させず、他 CI 通過後に
-  // worker が merge できるようにする。
-  // https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account
+  // lockFileMaintenance は minimumReleaseAge を enforce しないが、グローバル設定があると
+  // `renovate/stability-days` が永遠 PENDING で post され、platformAutomerge: false の
+  // worker による automerge を恒久 block する。null override で該当 PR の check 自体を抑止。
   "lockFileMaintenance": {
     "statusCheckNames": {
       "minimumReleaseAge": null


### PR DESCRIPTION
## 背景

[#648](https://github.com/nozomiishii/renovate/pull/648) で `platformAutomerge: false` に切り替えて以来、Renovate worker が PR の全 status check を gate にするようになりました。これにより lockFileMaintenance PR が以下の理由で恒久 stuck します。

- top-level `minimumReleaseAge: "3 days"` があると Renovate は lockFileMaintenance branch にも `renovate/stability-days` status check を post する
- 一方、lockFileMaintenance は仕様上 `minimumReleaseAge` を enforce しない ([Renovate docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account))
- 結果、stability-days は永遠 PENDING で残り、worker は branch を `BranchNotGreen` と判定して merge を block する

実例: [nozomiishii/git-harvest#125](https://github.com/nozomiishii/git-harvest/pull/125), [#653](https://github.com/nozomiishii/renovate/pull/653)
関連 Issue: [renovatebot/renovate#24275](https://github.com/renovatebot/renovate/issues/24275)

## 変更内容

`lockFileMaintenance.statusCheckNames.minimumReleaseAge: null` を追加し、lockFileMaintenance branch では stability-days check 自体を post しないようにする。

該当ロジック ([status-checks.ts](https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/update/branch/status-checks.ts)):

```typescript
const context = config.statusCheckNames?.minimumReleaseAge;
if (!context) {
  // Status check is null or an empty string, skipping status check addition.
  return;
}
```

`statusCheckNames` は `mergeable: true` なので nested override が default とマージされ、lockFileMaintenance branch にだけ null override が効く。通常 dep PR の挙動には影響しない。

## 効果

| PR 種別 | 影響 |
|---|---|
| 通常 dep PR | 変更なし。`renovate/stability-days` で 3 日待ち継続 |
| lockFileMaintenance PR | stability-days check が作られず、他 CI (test / validate / secret-scan / GitGuardian など) 通過後に Renovate worker が即 merge |

`:maintainLockFilesWeekly` の `schedule: before 4am on monday` は不変。月曜に PR 作成 → CI 通過 → 同日中に merge という flow になる。

## 検証

- `renovate-config-validator --strict default.json` で構文 OK 確認済み

## 既存 stuck PR への対応

すでに pending stability-days が付いている [nozomiishii/git-harvest#125](https://github.com/nozomiishii/git-harvest/pull/125) と [#653](https://github.com/nozomiishii/renovate/pull/653) は、本 PR 反映後に手動 close すれば来週月曜の Renovate run で新 config に従って PR が再作成される。
