### PR TITLE
chore(deps): bump pnpm from 10.33.2 to 11.0.8

### DIFF
--- a/default.json
+++ b/default.json
@@ -134,18 +134,5 @@
   // git submodule の ref 更新を追従対象にする (デフォルト false)
   "git-submodules": {
     "enabled": true
-  },
-
-  // 公式 manager が拾えない箇所の追従用 custom manager
-  "customManagers": [
-    // pnpm-workspace.yaml の useNodeVersion を node-version datasource で追従
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^pnpm-workspace\\.ya?ml$/"],
-      "matchStrings": ["useNodeVersion:\\s*(?<currentValue>[\\d.]+)"],
-      "datasourceTemplate": "node-version",
-      "depNameTemplate": "node",
-      "versioningTemplate": "node"
-    }
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,16 @@
     "lefthook": "2.1.6",
     "renovate": "43.150.0"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.8",
   "engines": {
     "node": "24.15.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.15.0",
+      "onFail": "download"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -40,13 +40,6 @@
   "engines": {
     "node": "24.15.0"
   },
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "version": "24.15.0",
-      "onFail": "download"
-    }
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
-      node:
-        specifier: runtime:24.15.0
-        version: runtime:24.15.0
       renovate:
         specifier: 43.150.0
         version: 43.150.0(typanion@3.14.0)
@@ -2345,127 +2342,6 @@ packages:
 
   node-html-parser@7.1.0:
     resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
-
-  node@runtime:24.15.0:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
-          targets:
-            - cpu: ppc64
-              os: aix
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-NyMxuWl3mrXRW5SYhPxur4jVr+h73ouogdZAC5EA/8Q=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-/9XuKTRnkn8+5zGlU+uI/R9Iz3TuvC10prq+SvIoZzs=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-c6/CNNVYwkkZh19RwtHqACoq2k6m+DYBo4OGn++mTu0=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-sfiJAKSxY2XqulYmkwT8Edp1gdvwNVLUSV+azh/AX20=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-ppc64le.tar.gz
-          targets:
-            - cpu: ppc64le
-              os: linux
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-+YVFVDnVL+m43mqPbQe/7MxzbepSfofqyv5ajXUWo4A=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-s390x.tar.gz
-          targets:
-            - cpu: s390x
-              os: linux
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-RINoctmuxJ8ea1KpqSKHLbmisC0jWmFqVoG2qF/sjYk=
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin:
-              node: node.exe
-            integrity: sha256-yet0Au2ibiun5EtnJ/yFqN5WxQlbH3Hr0wYokiEaoRY=
-            prefix: node-v24.15.0-win-arm64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-arm64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin:
-              node: node.exe
-            integrity: sha256-zFFJ6r1Td5zh573FQBZDYi0MfmgAreGJKKdn6UC7DmI=
-            prefix: node-v24.15.0-win-x64
-            type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-MemKqWCgZ9qR7f/V2TvEZle10qgClhLDWfXyrABgFSo=
-            type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64-musl.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-9Vr1vUicU0exE8pllMrgClSzC6V6xYdTJDEb/G9HYuM=
-            type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64-musl.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-              libc: musl
-    version: 24.15.0
-    hasBin: true
 
   nopt@9.0.0:
     resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
@@ -6447,8 +6323,6 @@ snapshots:
     dependencies:
       css-select: 5.2.2
       he: 1.2.0
-
-  node@runtime:24.15.0: {}
 
   nopt@9.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
+      node:
+        specifier: runtime:24.15.0
+        version: runtime:24.15.0
       renovate:
         specifier: 43.150.0
         version: 43.150.0(typanion@3.14.0)
@@ -2335,6 +2338,127 @@ packages:
 
   node-html-parser@7.1.0:
     resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
+
+  node@runtime:24.15.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-NyMxuWl3mrXRW5SYhPxur4jVr+h73ouogdZAC5EA/8Q=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-/9XuKTRnkn8+5zGlU+uI/R9Iz3TuvC10prq+SvIoZzs=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-c6/CNNVYwkkZh19RwtHqACoq2k6m+DYBo4OGn++mTu0=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-sfiJAKSxY2XqulYmkwT8Edp1gdvwNVLUSV+azh/AX20=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-+YVFVDnVL+m43mqPbQe/7MxzbepSfofqyv5ajXUWo4A=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-RINoctmuxJ8ea1KpqSKHLbmisC0jWmFqVoG2qF/sjYk=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-yet0Au2ibiun5EtnJ/yFqN5WxQlbH3Hr0wYokiEaoRY=
+            prefix: node-v24.15.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-zFFJ6r1Td5zh573FQBZDYi0MfmgAreGJKKdn6UC7DmI=
+            prefix: node-v24.15.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-MemKqWCgZ9qR7f/V2TvEZle10qgClhLDWfXyrABgFSo=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64-musl.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-9Vr1vUicU0exE8pllMrgClSzC6V6xYdTJDEb/G9HYuM=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 24.15.0
+    hasBin: true
 
   nopt@9.0.0:
     resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
@@ -6310,6 +6434,8 @@ snapshots:
     dependencies:
       css-select: 5.2.2
       he: 1.2.0
+
+  node@runtime:24.15.0: {}
 
   nopt@9.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,14 +8,14 @@
 # 不要・別経路で代替できるなら false。推移依存はコメントで導入経路を明記する
 allowBuilds:
   # ── 直接依存 ──
-  lefthook: false             # フック登録は @nozomiishii/postinstall 経由で行うため不要
+  lefthook: false # フック登録は @nozomiishii/postinstall 経由で行うため不要
 
   # ── 推移依存（renovate 経由） ──
-  better-sqlite3: true        # renovate のリポジトリキャッシュに使用
-  core-js-pure: true          # @babel/runtime-corejs3 → @qnighy/marshal 経由、polyfill
-  dtrace-provider: false      # bunyan 経由、macOS/Solaris の DTrace 連携用 optional 機能。失敗時は no-op fallback で動作するため build 不要
-  protobufjs: true            # @opentelemetry/exporter-trace-otlp-http 経由、OTLP 出力で使用
-  re2: true                   # renovate 直接、RE2 regex engine
+  better-sqlite3: true # renovate のリポジトリキャッシュに使用
+  core-js-pure: true # @babel/runtime-corejs3 → @qnighy/marshal 経由、polyfill
+  dtrace-provider: false # bunyan 経由、macOS/Solaris の DTrace 連携用 optional 機能。失敗時は no-op fallback で動作するため build 不要
+  protobufjs: true # @opentelemetry/exporter-trace-otlp-http 経由、OTLP 出力で使用
+  re2: true # renovate 直接、RE2 regex engine
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,15 +4,18 @@
 # pnpm config list
 # ```
 
-# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
-# パッケージ自身の install スクリプト実行は不要。
-# それ以外は renovate のネイティブ依存（better-sqlite3, re2, dtrace-provider 等）の
+# build script は未記載のものはデフォルトで実行しない (v11 の挙動)。
+# strictDepBuilds: false で「未記載＝warning」に格下げし、
+# install を止めずに済ませる。本当に build が必要なものだけ
+# allowBuilds に true で明示する
+strictDepBuilds: false
+
+# renovate のネイティブ依存（better-sqlite3, re2, dtrace-provider 等）の
 # install スクリプトを許可
 allowBuilds:
   better-sqlite3: true
   core-js-pure: true
   dtrace-provider: true
-  lefthook: false
   protobufjs: true
   re2: true
 
@@ -24,3 +27,6 @@ publicHoistPattern:
 
 # pinバージョンでインストールする
 savePrefix: ""
+
+# ログ出力形式をカスタマイズ
+reporter: append-only

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,17 @@
 # pnpm config list
 # ```
 
-# 使用するNode.jsのバージョン
-useNodeVersion: 24.15.0
+# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
+# パッケージ自身の install スクリプト実行は不要。
+# それ以外は renovate のネイティブ依存（better-sqlite3, re2, dtrace-provider 等）の
+# install スクリプトを許可
+allowBuilds:
+  better-sqlite3: true
+  core-js-pure: true
+  dtrace-provider: true
+  lefthook: false
+  protobufjs: true
+  re2: true
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:
@@ -15,12 +24,3 @@ publicHoistPattern:
 
 # pinバージョンでインストールする
 savePrefix: ""
-
-# 公開から3日未満のバージョンをインストールしない（サプライチェーン攻撃対策）
-# https://pnpm.io/settings#minimumreleaseage
-# NOTE: transitive dependency の再解決時にフォールバックが効かない pnpm のバグにより一時無効化
-# https://github.com/pnpm/pnpm/issues/11068
-# minimumReleaseAge: 4320
-
-# ログ出力形式をカスタマイズ
-reporter: append-only

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,17 +4,18 @@
 # pnpm config list
 # ```
 
-# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
-# パッケージ自身の install スクリプト実行は不要。
-# それ以外は renovate のネイティブ依存（better-sqlite3, re2, dtrace-provider 等）の
-# install スクリプトを許可
+# install スクリプトのポリシー: 実際に build/postinstall が動作に必要なら true、
+# 不要・別経路で代替できるなら false。推移依存はコメントで導入経路を明記する
 allowBuilds:
-  better-sqlite3: true
-  core-js-pure: true
-  dtrace-provider: true
-  lefthook: false
-  protobufjs: true
-  re2: true
+  # ── 直接依存 ──
+  lefthook: false             # フック登録は @nozomiishii/postinstall 経由で行うため不要
+
+  # ── 推移依存（renovate 経由） ──
+  better-sqlite3: true        # renovate のリポジトリキャッシュに使用
+  core-js-pure: true          # @babel/runtime-corejs3 → @qnighy/marshal 経由、polyfill
+  dtrace-provider: false      # bunyan 経由、macOS/Solaris の DTrace 連携用 optional 機能。失敗時は no-op fallback で動作するため build 不要
+  protobufjs: true            # @opentelemetry/exporter-trace-otlp-http 経由、OTLP 出力で使用
+  re2: true                   # renovate 直接、RE2 regex engine
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,17 +5,15 @@
 # ```
 
 # install スクリプトのポリシー: 実際に build/postinstall が動作に必要なら true、
-# 不要・別経路で代替できるなら false。推移依存はコメントで導入経路を明記する
+# 不要・別経路で代替できるなら false。
+# コメント形式: # <package.json 依存 → ... → 自身までの全経路> | <用途>
 allowBuilds:
-  # ── 直接依存 ──
-  lefthook: false # フック登録は @nozomiishii/postinstall 経由で行うため不要
-
-  # ── 推移依存（renovate 経由） ──
-  better-sqlite3: true # renovate のリポジトリキャッシュに使用
-  core-js-pure: true # @babel/runtime-corejs3 → @qnighy/marshal 経由、polyfill
-  dtrace-provider: false # bunyan 経由、macOS/Solaris の DTrace 連携用 optional 機能。失敗時は no-op fallback で動作するため build 不要
-  protobufjs: true # @opentelemetry/exporter-trace-otlp-http 経由、OTLP 出力で使用
-  re2: true # renovate 直接、RE2 regex engine
+  lefthook: false # lefthook | フック登録は @nozomiishii/postinstall 経由で行うため不要
+  better-sqlite3: true # renovate → better-sqlite3 | リポジトリキャッシュに使用
+  core-js-pure: true # renovate → @qnighy/marshal → @babel/runtime-corejs3 → core-js-pure | polyfill
+  dtrace-provider: false # renovate → bunyan → dtrace-provider | macOS/Solaris の DTrace 連携用 optional 機能。失敗時は no-op fallback で動作するため build 不要
+  protobufjs: true # renovate → protobufjs | OTLP 出力で使用
+  re2: true # renovate → re2 | RE2 regex engine
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,18 +4,15 @@
 # pnpm config list
 # ```
 
-# build script は未記載のものはデフォルトで実行しない (v11 の挙動)。
-# strictDepBuilds: false で「未記載＝warning」に格下げし、
-# install を止めずに済ませる。本当に build が必要なものだけ
-# allowBuilds に true で明示する
-strictDepBuilds: false
-
-# renovate のネイティブ依存（better-sqlite3, re2, dtrace-provider 等）の
+# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
+# パッケージ自身の install スクリプト実行は不要。
+# それ以外は renovate のネイティブ依存（better-sqlite3, re2, dtrace-provider 等）の
 # install スクリプトを許可
 allowBuilds:
   better-sqlite3: true
   core-js-pure: true
   dtrace-provider: true
+  lefthook: false
   protobufjs: true
   re2: true
 


### PR DESCRIPTION
## 概要

pnpm を v10.33.2 から v11.0.8 にバージョン更新。v11 はサプライチェーン保護のデフォルト ON や設定スキーマの整理など破壊的変更が多いため、それに合わせて設定ファイルを追従させる。あわせて Renovate プリセット側でも `useNodeVersion` を追従していた custom manager を削除する。

## 主な変更

- `package.json`
  - `packageManager`: `pnpm@10.33.2` → `pnpm@11.0.8`
  - `useNodeVersion`（v11 で削除）の代替には `devEngines.runtime` を採用せず、既存の `engines.node` をそのまま信頼の source として活用。理由は以下の通り
    - Renovate が `devEngines.runtime` の自動更新に未対応 ([renovatebot/renovate#38067](https://github.com/renovatebot/renovate/issues/38067))
    - fnm v1.38+ が `--resolve-engines` をデフォルト ON にし `engines.node` を読むため、ローカルの Node 自動切替もこれで成立
    - `actions/setup-node@v6` も `node-version-file: 'package.json'` で `engines.node` を読むので CI も同じ source 一本でカバーできる
- `pnpm-workspace.yaml`
  - `useNodeVersion` / `reporter` / `minimumReleaseAge` のコメントブロックを削除（v11 で削除 or デフォルト 1 日に変更）
  - `allowBuilds` を追加（v11 では `strictDepBuilds` が default ON）
    - renovate 配下のネイティブ依存を `true` で許可: `better-sqlite3`、`core-js-pure`、`dtrace-provider`、`protobufjs`、`re2`
    - `lefthook: false`（フック登録は `@nozomiishii/postinstall` 経由のため install スクリプト実行は不要）
- `default.json`（Renovate プリセット本体）
  - `pnpm-workspace.yaml` の `useNodeVersion` を追従していた custom manager を削除（v11 で `useNodeVersion` 自体が消えたため不要）
- `pnpm-lock.yaml` を v11 で再生成

## v11 主要破壊的変更（参考）

- Node.js 22+ 必須（本リポジトリは 24.15.0 なので影響なし）
- `useNodeVersion` 設定削除（本リポでは `engines.node` で代替）
- `onlyBuiltDependencies` / `neverBuiltDependencies` / `ignoredBuiltDependencies` / `ignoreDepScripts` を `allowBuilds` マップに統合
- `.npmrc` は auth/registry のみへ縮小
- 環境変数 prefix が `npm_config_*` → `pnpm_config_*` に
- `minimumReleaseAge` のデフォルトが 1440 分（1 日）に

## 動作確認

- ローカルで `CI=true pnpm install` がエラー・警告なしで成功
- ネイティブ依存（better-sqlite3, re2 等）の install スクリプトも正常完了
- `renovate-config-validator --strict default.json` も pass
