### PR TITLE
chore: remove redundant install hook now covered by startup.sh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,14 +2,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pnpm install"
-          }
-        ]
-      },
-      {
         "matcher": "startup",
         "hooks": [
           {


### PR DESCRIPTION
## Summary
- [#672](https://github.com/nozomiishii/renovate/pull/672) で startup hook を導入した後に残っていた、`pnpm install` を session 開始時に無条件実行する旧エントリを削除
- 旧エントリは `matcher` 無しのため resume / clear / compact でも毎回 `pnpm install` が走っていた
- startup.sh が `node_modules` 不在時のみフォールバック install を実行し、lock 更新は lefthook post-merge がカバーするので、旧エントリは不要

## なぜ
- 重複エントリで startup 時の install が二重に走る無駄を削減
- resume/clear/compact での無条件 install も大半は no-op で時間とログを浪費していた
- SessionStart hook を `startup.sh` 1 本に集約してシンプルに

## Test plan
- [x] `bash -n .claude/hooks/startup.sh`（syntax check）
- [x] `jq '.' .claude/settings.json`（JSON valid）

refs nozomiishii/workspaces#34
