### PR TITLE
chore: add prettier --cache flag to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "pnpm prettier . --check",
     "format:fix": "pnpm prettier . --write",
     "postinstall": "postinstall",
-    "prettier": "prettier --ignore-unknown",
+    "prettier": "prettier --ignore-unknown --cache",
     "validate": "renovate-config-validator --strict default.json"
   },
   "devDependencies": {


### PR DESCRIPTION
## 概要

`@nozomiishii/prettier-config` の最新 init template に合わせて、`prettier` script に `--cache` flag を追加する。

## 背景

configs リポジトリの nozomiishii/configs#2285 で `nozo-prettier-init` の生成 scripts が更新され、`--cache` を `prettier` script に集約する形になった (`format` / `format:fix` script は action のみを持つ)。既存 repo は古い init template の名残で `--cache` が無いため、手動で揃える。

## 変更

- root `package.json` の `scripts.prettier` に `--cache` を追加: `prettier --ignore-unknown` → `prettier --ignore-unknown --cache`

## 影響範囲

`pnpm prettier` / `pnpm format` / `pnpm format:fix` 実行時に `node_modules/.cache/prettier/.prettier-cache` がキャッシュとして使われ高速化される。出力結果に変化なし。
