### PR TITLE
feat: track op CLI version on 1password/load-secrets-action

### DIFF
--- a/default.json
+++ b/default.json
@@ -128,24 +128,12 @@
     }
   ],
 
-  // GitHub Actions の `with: version:` で渡すツールのバージョンを Renovate に追従させる custom manager。
-  // 公式 preset (githubActionsVersions) は XXX_VERSION 形式の env 行しか拾わず `with: version:` には効かないため、
-  // その preset と同じ「`# renovate:` コメントを目印にする」流儀を `version:` 行向けに最小改変したもの。
-  //   - 公式 preset 一覧:       https://docs.renovatebot.com/presets-customManagers/
-  //   - regex manager の使い方: https://docs.renovatebot.com/modules/manager/regex/
-  //
-  // 使い方: 追従したい `version:` の直上に `# renovate:` コメントを 1 行置く (datasource/depName は公式 preset と同形)。
-  //   - uses: 1password/load-secrets-action@<sha> # v4
-  //     with:
-  //       # renovate: datasource=docker depName=1password/op versioning=semver
-  //       version: "2.34.0"   # op CLI 本体。zizmor (unpinned-tools) 対策でリテラル固定
-  //     env:
-  //       OP_SERVICE_ACCOUNT_TOKEN: ${{ ... }}
-  //
-  // コメントを目印にするので、step の並び順 (env: が先など) や他 input の有無に依存せず、
-  // marker の無い他 step の version: を誤検出することもない。datasource/depName は各 caller のコメント側で指定する。
-  // 上の例では op バイナリは従来どおり 1Password CDN から DL され、Docker タグ (1password/op) は
-  // 「どの版が存在するか」を Renovate に教える version oracle として使う。
+  // `with: version:` で固定したツールのバージョンを Renovate に追従させる custom manager。
+  // 追従したい version: の直上に、公式 preset と同形の `# renovate:` コメントを 1 行置くだけ:
+  //   with:
+  //     # renovate: datasource=docker depName=1password/op versioning=semver
+  //     version: "2.34.0"
+  // コメントが目印なので step の並び順や他 input の有無に左右されず、他 step の version: も誤検出しない。
   "customManagers": [
     {
       "description": "Track tool versions pinned via `with: version:` in workflows, anchored on a `# renovate:` annotation (same convention as the githubActionsVersions preset, adapted for `version:` instead of *_VERSION env vars)",

--- a/default.json
+++ b/default.json
@@ -128,6 +128,27 @@
     }
   ],
 
+  // GitHub Actions の action input に埋め込んだツールバージョンを追従する custom manager。
+  // 公式 customManagers:githubActionsVersions preset は `<KEY>_VERSION:` env 行しか拾えず
+  // `with: version:` には効かないため、ここで補完する。
+  "customManagers": [
+    {
+      // 1password/load-secrets-action の version: は op CLI 本体のバージョン。zizmor unpinned-tools
+      // 用にリテラル pin しているが、放置すると op CLI だけ renovate に追従されず rot する。公式
+      // 1password/op の Docker タグ (clean semver) を datasource にして semver 追従させる。version: が
+      // 1password step の with: 直下 (コメント行のみ挟む) にある時だけマッチし、他 step の version: は誤検出しない。
+      "description": "Track the op CLI version pinned on 1password/load-secrets-action (kept literal for zizmor unpinned-tools), sourced from the official 1password/op Docker Hub tags",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)\\.github/workflows/[^/]+\\.yaml$/"],
+      "matchStrings": [
+        "1password/load-secrets-action@\\S+[^\\n]*\\s+with:(?:\\s*#[^\\n]*)*\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "1password/op",
+      "versioningTemplate": "semver"
+    }
+  ],
+
   // 更新後に lockfile を自動 dedupe (pnpm dedupe / npm dedupe)
   "postUpdateOptions": ["pnpmDedupe", "npmDedupe"],
 

--- a/default.json
+++ b/default.json
@@ -128,24 +128,32 @@
     }
   ],
 
-  // GitHub Actions の with: で渡すツールのバージョンを Renovate に追従させる custom manager。
-  // 公式 preset (githubActionsVersions) は XXX_VERSION 形式の環境変数しか見ず、
-  // with: version: を拾えないため、ここで補う。
+  // GitHub Actions の `with: version:` で渡すツールのバージョンを Renovate に追従させる custom manager。
+  // 公式 preset (githubActionsVersions) は XXX_VERSION 形式の env 行しか拾わず `with: version:` には効かないため、
+  // その preset と同じ「`# renovate:` コメントを目印にする」流儀を `version:` 行向けに最小改変したもの。
+  //   - 公式 preset 一覧:       https://docs.renovatebot.com/presets-customManagers/
+  //   - regex manager の使い方: https://docs.renovatebot.com/modules/manager/regex/
+  //
+  // 使い方: 追従したい `version:` の直上に `# renovate:` コメントを 1 行置く (datasource/depName は公式 preset と同形)。
+  //   - uses: 1password/load-secrets-action@<sha> # v4
+  //     with:
+  //       # renovate: datasource=docker depName=1password/op versioning=semver
+  //       version: "2.34.0"   # op CLI 本体。zizmor (unpinned-tools) 対策でリテラル固定
+  //     env:
+  //       OP_SERVICE_ACCOUNT_TOKEN: ${{ ... }}
+  //
+  // コメントを目印にするので、step の並び順 (env: が先など) や他 input の有無に依存せず、
+  // marker の無い他 step の version: を誤検出することもない。datasource/depName は各 caller のコメント側で指定する。
+  // 上の例では op バイナリは従来どおり 1Password CDN から DL され、Docker タグ (1password/op) は
+  // 「どの版が存在するか」を Renovate に教える version oracle として使う。
   "customManagers": [
     {
-      // 1password/load-secrets-action の version: は op CLI 本体のバージョン。
-      // zizmor (unpinned-tools) 対策で値を固定しているが、そのままだと Renovate が更新できず古くなる。
-      // そこで公式 1password/op の Docker タグ (= op のリリース) を datasource にして新しい semver を追従する。
-      // マッチ対象は 1password step 内の version: だけ (他 step の version: は拾わない)。
-      "description": "Track the op CLI version pinned on 1password/load-secrets-action (kept literal for zizmor unpinned-tools), sourced from the official 1password/op Docker Hub tags",
+      "description": "Track tool versions pinned via `with: version:` in workflows, anchored on a `# renovate:` annotation (same convention as the githubActionsVersions preset, adapted for `version:` instead of *_VERSION env vars)",
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)\\.github/workflows/[^/]+\\.yaml$/"],
       "matchStrings": [
-        "1password/load-secrets-action@\\S+[^\\n]*\\s+with:(?:\\s*#[^\\n]*)*\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "1password/op",
-      "versioningTemplate": "semver"
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ]
     }
   ],
 

--- a/default.json
+++ b/default.json
@@ -128,15 +128,15 @@
     }
   ],
 
-  // GitHub Actions の action input に埋め込んだツールバージョンを追従する custom manager。
-  // 公式 customManagers:githubActionsVersions preset は `<KEY>_VERSION:` env 行しか拾えず
-  // `with: version:` には効かないため、ここで補完する。
+  // GitHub Actions の with: で渡すツールのバージョンを Renovate に追従させる custom manager。
+  // 公式 preset (githubActionsVersions) は XXX_VERSION 形式の環境変数しか見ず、
+  // with: version: を拾えないため、ここで補う。
   "customManagers": [
     {
-      // 1password/load-secrets-action の version: は op CLI 本体のバージョン。zizmor unpinned-tools
-      // 用にリテラル pin しているが、放置すると op CLI だけ renovate に追従されず rot する。公式
-      // 1password/op の Docker タグ (clean semver) を datasource にして semver 追従させる。version: が
-      // 1password step の with: 直下 (コメント行のみ挟む) にある時だけマッチし、他 step の version: は誤検出しない。
+      // 1password/load-secrets-action の version: は op CLI 本体のバージョン。
+      // zizmor (unpinned-tools) 対策で値を固定しているが、そのままだと Renovate が更新できず古くなる。
+      // そこで公式 1password/op の Docker タグ (= op のリリース) を datasource にして新しい semver を追従する。
+      // マッチ対象は 1password step 内の version: だけ (他 step の version: は拾わない)。
       "description": "Track the op CLI version pinned on 1password/load-secrets-action (kept literal for zizmor unpinned-tools), sourced from the official 1password/op Docker Hub tags",
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)\\.github/workflows/[^/]+\\.yaml$/"],


### PR DESCRIPTION
## 概要

`1password/load-secrets-action` の `version:` input（= op CLI 本体のバージョン）を Renovate の追従対象にする custom manager を追加する。

## 背景

zizmor v1.25.0 で追加された `unpinned-tools` audit が `1password/load-secrets-action` の `version:` 未指定 / `latest` / `${{ ... }}` 式を検出するようになった。これを満たすには `version: "2.34.0"` のようにリテラルで pin する必要があるが、Renovate はこの input 値を依存と認識しないため、action 本体 (`uses:` の digest) は更新されても **op CLI 側だけ永久に固定されて rot する**。

## 対応

- 公式 `customManagers:githubActionsVersions` preset は `<KEY>_VERSION:` env 行しかマッチせず `with: version:` には効かないため、自前の regex custom manager を追加。
- 公式の 1Password Docker イメージ `1password/op`（Docker Hub・clean semver タグ）を datasource にし、`version:` のリテラル値を semver で追従させる。op バイナリ自体は従来どおり 1Password CDN から DL され、Docker タグは「どのバージョンが存在するか」を Renovate に教える version oracle としてのみ使う。
- regex は 1password step の `with:` 直下（コメント行のみ挟む）の `version:` だけにマッチする形に絞り、他 step の `version:` を誤検出しない。lookahead 不使用で re2 でも動作。
- `customManagers` は `mergeable: true` の array option なので、`extends` 経由の `customManagers:makefileVersions` preset と連結され、既存の Makefile 追従は壊さない。

## 検証

- `renovate-config-validator --strict default.json` → `Config validated successfully`
- `prettier --check` 通過

## 関連

- caller 側 (`nozomiishii/workflows`) の該当アノテーション付与は別 PR（zizmor-action bump の PR）で対応。
