### PR TITLE
chore: remove commit/PR format rules from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,6 @@
 
 このリポジトリで Claude Code (claude.ai/code) が作業する際のガイドラインです。
 
-## Git・GitHub 運用ルール
-
-- PR タイトルは英語 semantic 形式で、CI の semantic pull request チェックに従う。詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。
-
 ## アーキテクチャ概要
 
 `renovate` は Renovate Bot の共有設定パッケージです。エントリポイントは `default.json`（`extends` や best practices を組み合わせた主設定）。


### PR DESCRIPTION
## 概要

`CLAUDE.md` から PR タイトル / コミットメッセージの形式ルールを削除した。これらは git hooks / CI（commitlint・semantic-pull-request）が機械的に検査するため、CLAUDE.md に重複して持つ必要がなくなった。

## 補足

リリース・Conventional Commits の BREAKING CHANGE 方針は形式ルールでなく意味的判断（release-please の誤 bump 防止）なので残している。