### PR TITLE
feat: track bunx package versions in lefthook.yaml

### DIFF
--- a/default.json
+++ b/default.json
@@ -128,10 +128,7 @@
     }
   ],
 
-  // `# renovate:` アンカーで固定したツールのバージョンを Renovate に追従させる custom manager。
-  // 追従したい値の直上に、公式 preset と同形の `# renovate:` コメントを 1 行置くだけ。
-  // コメントが目印なので並び順や他 input に左右されず、無関係な version: / @バージョン を誤検出しない。
-  // 対応する2形:
+  // 追従したい値の直上に `# renovate:` コメントを置くと version を Renovate が追従する。
   //   workflows の `with: version:`
   //     # renovate: datasource=docker depName=1password/op versioning=semver
   //     version: "2.34.0"
@@ -140,7 +137,7 @@
   //     run: bunx -p @nozomiishii/commitlint-config@1.5.0 nozo-commitlint --edit {1}
   "customManagers": [
     {
-      "description": "Track tool versions anchored on a `# renovate:` annotation (same convention as the githubActionsVersions preset). Covers `with: version:` in workflows and `bunx <pkg>@<version>` run commands in lefthook.yaml (non-Node repos pin shared CLIs via bunx instead of node_modules).",
+      "description": "Track versions anchored on a `# renovate:` comment: `version:` in workflows and `bunx <pkg>@<version>` in lefthook.yaml.",
       "customType": "regex",
       "managerFilePatterns": [
         "/(^|/)\\.github/workflows/[^/]+\\.yaml$/",

--- a/default.json
+++ b/default.json
@@ -128,19 +128,26 @@
     }
   ],
 
-  // `with: version:` で固定したツールのバージョンを Renovate に追従させる custom manager。
-  // 追従したい version: の直上に、公式 preset と同形の `# renovate:` コメントを 1 行置くだけ:
-  //   with:
+  // `# renovate:` アンカーで固定したツールのバージョンを Renovate に追従させる custom manager。
+  // 追従したい値の直上に、公式 preset と同形の `# renovate:` コメントを 1 行置くだけ。
+  // コメントが目印なので並び順や他 input に左右されず、無関係な version: / @バージョン を誤検出しない。
+  // 対応する2形:
+  //   workflows の `with: version:`
   //     # renovate: datasource=docker depName=1password/op versioning=semver
   //     version: "2.34.0"
-  // コメントが目印なので step の並び順や他 input の有無に左右されず、他 step の version: も誤検出しない。
+  //   lefthook.yaml の `bunx <pkg>@<version>` (node_modules を作らない非 Node repo 用)
+  //     # renovate: datasource=npm depName=@nozomiishii/commitlint-config
+  //     run: bunx -p @nozomiishii/commitlint-config@1.5.0 nozo-commitlint --edit {1}
   "customManagers": [
     {
-      "description": "Track tool versions pinned via `with: version:` in workflows, anchored on a `# renovate:` annotation (same convention as the githubActionsVersions preset, adapted for `version:` instead of *_VERSION env vars)",
+      "description": "Track tool versions anchored on a `# renovate:` annotation (same convention as the githubActionsVersions preset). Covers `with: version:` in workflows and `bunx <pkg>@<version>` run commands in lefthook.yaml (non-Node repos pin shared CLIs via bunx instead of node_modules).",
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)\\.github/workflows/[^/]+\\.yaml$/"],
+      "managerFilePatterns": [
+        "/(^|/)\\.github/workflows/[^/]+\\.yaml$/",
+        "/(^|/)lefthook\\.ya?ml$/"
+      ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+(?:version:\\s*[\"']?|run:[^\\n]*@)(?<currentValue>[^\"'\\s]+)"
       ]
     }
   ],


### PR DESCRIPTION
## 概要

`# renovate:` アンカー方式の custom manager を、lefthook.yaml の `bunx <pkg>@<version>` run コマンドにも対応させる。

node_modules / package.json を作らない非 Node repo (例: OpenTofu の `nozomiishii/infra`) が、共有 CLI (`@nozomiishii/commitlint-config`、`git-harvest`) を bunx で pin しつつ Renovate 追従できるようにする。

## 変更

- `managerFilePatterns` に `lefthook.yaml` を追加
- matchString を1本に統一。値の手前だけ alternation `(?:version:…|run:[^\n]*@)` にして `currentValue` は1つ。re2 は同名グループの重複を許さないため、この形にする
- run は greedy な `[^\n]*@` で行内最後の `@`(= version の @)を掴むので、`@scope/name@version` のスコープ `@` を誤拾いしない

## 検証

- `renovate-config-validator`: Config validated successfully
- 実 matchString での抽出確認:
  - `version: "2.34.0"` / `"v16.6.0"` / `3.20`(quote 無し)→ 各 `currentValue` 正解
  - `bunx -p @nozomiishii/commitlint-config@1.5.0` → `1.5.0`
  - `bunx git-harvest@0.2.2` → `0.2.2`

## 影響

`github>nozomiishii/renovate` を extends する全 repo に効く。既存の workflows `with: version:` 追従は維持(同一 matchString が両形を処理)。

## 注意

run の version は行内で最後の `@` を版とみなす(greedy last-@)。`bunx pkg@1.2.3 ... @something` のように版の後ろに `@` が来る書き方をすると誤検出する。bunx-in-lefthook の通常用法では版が最後の `@` なので問題ない。
