### PR TITLE
feat: redirect OpenTofu required_version to opentofu/opentofu releases

### DIFF
--- a/default.json
+++ b/default.json
@@ -115,6 +115,20 @@
       "rangeStrategy": "bump"
     },
 
+    // OpenTofu の required_version 追従。
+    // terraform manager は .tf の required_version を hashicorp/terraform (Terraform の github releases) で
+    // 追う仕様で depName が固定のため、OpenTofu repo では存在しない Terraform 版が required_version に
+    // 流し込まれる事故が起きる (nozomiishii/infra で 1.12.1 → 1.15.5 に上げられ tofu init が弾かれた)。
+    // overridePackageName で packageName を opentofu/opentofu にリダイレクトし OpenTofu の release を追わせる。
+    // 除外でなくリダイレクトなので新版への自動追従も維持される。
+    // required_version depType を持たない repo (Node 系等) では何もマッチせず無害。
+    // https://github.com/nozomiishii/renovate/issues/712
+    {
+      "matchDepTypes": ["required_version"],
+      "matchDepNames": ["hashicorp/terraform"],
+      "overridePackageName": "opentofu/opentofu"
+    },
+
     // 自前 (nozomiishii/*) パッケージは top-level minimumReleaseAge が
     // 課す 3 日待ちを解除して即時取り込みする。
     // git-harvest / pm は scope なしで公開している自前パッケージなので明示列挙。

--- a/default.json
+++ b/default.json
@@ -116,12 +116,6 @@
     },
 
     // OpenTofu の required_version 追従。
-    // terraform manager は .tf の required_version を hashicorp/terraform (Terraform の github releases) で
-    // 追う仕様で depName が固定のため、OpenTofu repo では存在しない Terraform 版が required_version に
-    // 流し込まれる事故が起きる (nozomiishii/infra で 1.12.1 → 1.15.5 に上げられ tofu init が弾かれた)。
-    // overridePackageName で packageName を opentofu/opentofu にリダイレクトし OpenTofu の release を追わせる。
-    // 除外でなくリダイレクトなので新版への自動追従も維持される。
-    // required_version depType を持たない repo (Node 系等) では何もマッチせず無害。
     // https://github.com/nozomiishii/renovate/issues/712
     {
       "matchDepTypes": ["required_version"],


### PR DESCRIPTION
## 概要

renovate の terraform manager は `.tf` の `required_version` を `hashicorp/terraform`（Terraform の github releases）で追う仕様で、`depName` がハードコードされている。OpenTofu repo でこれを放置すると Terraform の最新版が `required_version` に流し込まれ、OpenTofu に存在しないバージョンになる（`nozomiishii/infra` で `1.12.1` → `1.15.5` に上げられ `tofu init` が弾かれた）。

## 変更内容

`default.json` の `packageRules` に、`required_version` の `packageName` を `opentofu/opentofu` にリダイレクトするルールを1つ追加（nozomiishii ルールは「必ず最後」なので、その直前に配置）。

```json
{
  "matchDepTypes": ["required_version"],
  "matchDepNames": ["hashicorp/terraform"],
  "overridePackageName": "opentofu/opentofu"
}
```

除外でなくリダイレクトなので、新版への自動追従も維持される。customManager は不要。

## 検証

- `renovate-config-validator --strict default.json` → `Config validated successfully`（pre-commit でも実行）
- 無害性: renovate 実装上 `TerraformVersionExtractor` は `.tf` の terraform block に `required_version` がある時だけ dep を生成。Node 系 repo では `required_version` depType の dep が出ず、このルールは何にもマッチしない

## スコープ外（利用側 nozomiishii/infra で対応）

- `.opentofu-version` 削除と `required_version` への single source 化
- `TENV_AUTO_INSTALL=true`
- setup-opentofu の版指定見直し

Closes #712
