### PR TITLE
feat: track devEngines.runtime node version via customManager

### DIFF
--- a/default.json
+++ b/default.json
@@ -109,6 +109,14 @@
       "groupName": "artifact"
     },
 
+    // engines.node (npm manager) と devEngines.runtime.version (customManager) を
+    // 同一 PR にまとめて Node.js バージョンの乖離を防ぐ
+    {
+      "matchDepNames": ["node"],
+      "matchDatasources": ["node-version"],
+      "groupName": "node"
+    },
+
     // peerDeps はライブラリ互換性維持のため pin せず範囲を bump
     {
       "matchDepTypes": ["peerDependencies"],
@@ -157,7 +165,7 @@
     {
       "description": "Track devEngines.runtime Node.js version in package.json.",
       "customType": "regex",
-      "managerFilePatterns": ["(^|/)package\\.json$"],
+      "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
         "\"devEngines\"\\s*:\\s*\\{\\s*\"runtime\"\\s*:\\s*\\{\\s*\"name\"\\s*:\\s*\"node\"\\s*,\\s*\"version\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""
       ],

--- a/default.json
+++ b/default.json
@@ -150,6 +150,21 @@
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+[A-Za-z0-9_-]*[Vv][Ee][Rr][Ss][Ii][Oo][Nn]:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
       ]
     },
+    // devEngines.runtime の Node.js バージョンを追従。
+    // npm manager のネイティブ対応が来たら撤去:
+    // https://github.com/renovatebot/renovate/pull/43369
+    // https://github.com/renovatebot/renovate/issues/38067
+    {
+      "description": "Track devEngines.runtime Node.js version in package.json.",
+      "customType": "regex",
+      "managerFilePatterns": ["(^|/)package\\.json$"],
+      "matchStrings": [
+        "\"devEngines\"\\s*:\\s*\\{\\s*\"runtime\"\\s*:\\s*\\{\\s*\"name\"\\s*:\\s*\"node\"\\s*,\\s*\"version\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    },
     // lefthook.yaml の `bunx <pkg>@<version>` を追従。
     // node_modules を作らない非 Node repo 用。
     //   # renovate: datasource=npm depName=@nozomiishii/commitlint-config


### PR DESCRIPTION
## Summary

- npm manager が `devEngines.runtime.version` の更新 PR を作らないため、`engines.node` との乖離が発生していた
- regex customManager を追加して `devEngines.runtime.version` の Node.js バージョンを `node-version` datasource で追従させる

## 背景

Renovate は `devEngines` を constraint として読む（lockfile 生成時の toolchain 選択）が、バージョン更新 PR は作らない。ネイティブ対応の PR がレビュー中:

- https://github.com/renovatebot/renovate/pull/43369
- https://github.com/renovatebot/renovate/issues/38067

ネイティブ対応がマージされたら、この customManager は撤去する。

## Test plan

- [ ] CI 通過
- [ ] `renovate-config-validator --strict` 通過（pre-commit で検証済み）
- [ ] マージ後、Renovate が `devEngines.runtime.version` の更新 PR を作ること

https://claude.ai/code/session_012DddpzkwJETEgfCqrcD8tT