### PR TITLE
fix: prevent engines.node range from being pinned

### DIFF
--- a/default.json
+++ b/default.json
@@ -109,12 +109,13 @@
       "groupName": "artifact"
     },
 
-    // engines.node (npm manager) と devEngines.runtime.version (customManager) を
-    // 同一 PR にまとめて Node.js バージョンの乖離を防ぐ
+    // engines.node は Vercel 等の対応状況に合わせて手動管理するため、
+    // rangeStrategy を auto にして範囲指定 (>=24) のピン化を防ぐ。
+    // ピン済み (24.17.0) の repo ではそのまま更新される
     {
+      "matchDepTypes": ["engines"],
       "matchDepNames": ["node"],
-      "matchDatasources": ["node-version"],
-      "groupName": "node"
+      "rangeStrategy": "auto"
     },
 
     // peerDeps はライブラリ互換性維持のため pin せず範囲を bump


### PR DESCRIPTION
## Summary

- `rangeStrategy: "pin"` が `engines.node` の範囲指定（`>=24`）を `v26.3.1` にピン化していた
- node グルーピングルールを `engines` depType 向けの `rangeStrategy: "auto"` に置き換え
- `auto` なら既にピン済み（`24.17.0`）の repo はそのまま更新、範囲指定の repo は元の形式を維持

## 背景

[git-harvest#237](https://github.com/nozomiishii/git-harvest/pull/237) で `engines.node: ">=24"` が `v26.3.1` にピン化された。Vercel 対応状況に合わせて手動管理する方針なので、Renovate が勝手にピン化すべきでない。

## Test plan

- [ ] CI 通過
- [ ] マージ後、git-harvest の Renovate node PR で `engines.node: ">=24"` が変更されないこと
- [ ] dotfiles の Renovate node PR で `engines.node: "24.17.0"` は引き続き更新されること

https://claude.ai/code/session_012DddpzkwJETEgfCqrcD8tT