### PR TITLE
feat: add required summary gate job to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
   required:
     needs: [static]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,3 +38,15 @@ jobs:
 
       - name: Lint
         run: pnpm validate
+
+  required:
+    needs: [static]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled"
+          exit 1


### PR DESCRIPTION
## 概要

- CI ワークフローに `required` サマリーゲートジョブを追加
- `static` ジョブの結果を集約し、失敗やキャンセル時に明示的にエラーを返す
- branch protection の required status check を `required` ジョブ 1 つに統一できる

## 背景

nozomiishii/dev#2928 のパターンに倣い、全リポジトリの CI に required サマリーゲートジョブを導入する。

## テスト計画

- [ ] CI が通ることを確認
- [ ] `required` ジョブが `static` の成功後に成功することを確認

https://claude.ai/code/session_01WT3uDc26XFEw3aMy8rJgJ3