### PR TITLE
chore: switch devEngines.runtime customManager from regex to JSONata

### DIFF
--- a/default.json
+++ b/default.json
@@ -159,20 +159,27 @@
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+[A-Za-z0-9_-]*[Vv][Ee][Rr][Ss][Ii][Oo][Nn]:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
       ]
     },
-    // devEngines.runtime の Node.js バージョンを追従。
+    // devEngines.runtime のバージョンを追従。
     // npm manager のネイティブ対応が来たら撤去:
     // https://github.com/renovatebot/renovate/pull/43369
     // https://github.com/renovatebot/renovate/issues/38067
     {
       "description": "Track devEngines.runtime Node.js version in package.json.",
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)package\\.json$/"],
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/package.json/"],
       "matchStrings": [
-        "\"devEngines\"\\s*:\\s*\\{\\s*\"runtime\"\\s*:\\s*\\{\\s*\"name\"\\s*:\\s*\"node\"\\s*,\\s*\"version\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "depNameTemplate": "node",
-      "datasourceTemplate": "node-version",
-      "versioningTemplate": "node"
+        "$exists(devEngines.runtime) and devEngines.runtime.name = 'node' ? [{\"depName\": \"node\", \"currentValue\": devEngines.runtime.version, \"datasource\": \"node-version\", \"versioning\": \"node\"}] : []"
+      ]
+    },
+    {
+      "description": "Track devEngines.runtime Bun version in package.json.",
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/package.json/"],
+      "matchStrings": [
+        "$exists(devEngines.runtime) and devEngines.runtime.name = 'bun' ? [{\"depName\": \"bun\", \"currentValue\": devEngines.runtime.version, \"datasource\": \"github-releases\", \"packageName\": \"oven-sh/bun\", \"extractVersion\": \"^bun-v(?<version>.+)$\"}] : []"
+      ]
     },
     // lefthook.yaml の `bunx <pkg>@<version>` を追従。
     // node_modules を作らない非 Node repo 用。


### PR DESCRIPTION
## Summary
- devEngines.runtime の customManager を regex から JSONata に移行
  - regex はキー順序に依存していたが、JSONata は JSON 構造をそのまま扱える
- Bun runtime の追従を追加（datasource: github-releases, packageName: oven-sh/bun）
- npm manager のネイティブ対応 PR がマージされたら撤去: https://github.com/renovatebot/renovate/pull/43369

## Test plan
- [ ] Renovate の dry-run で devEngines.runtime が正しく検出されることを確認
- [ ] node / bun それぞれの package.json で動作確認

https://claude.ai/code/session_01UVfRtsTJs4SZKFLbm7yVbw