### PR TITLE
fix: add unique name to required gate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,8 @@ jobs:
         run: pnpm validate
 
   required:
+    # name 変更時は infra 側も更新する
+    name: CI / required
     needs: [static]
     if: always()
     runs-on: ubuntu-slim

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm validate
 
   required:
-    # name 変更時は infra 側も更新する
+    # name 変更時は infra 側の required_status_checks も更新する
     name: CI / required
     needs: [static]
     if: always()


### PR DESCRIPTION
## 概要

- required ゲートジョブにユニークな name (`CI / required`) を付与
- 同名チェックコンテキストの衝突によるレースコンディションを防止

infra 側の ruleset 更新は別 PR で対応。

https://claude.ai/code/session_01TkQRPr4KydLk53utjxtLRJ