### PR TITLE
fix: restore postUpdateOptions (pnpmDedupe + npmDedupe)

### DIFF
--- a/default.json
+++ b/default.json
@@ -188,11 +188,8 @@
     }
   ],
 
-  // pnpmDedupe / npmDedupe は意図的に無効化。
-  // pnpm v11 の pnpm dedupe が 3GB 超のメモリを消費し
-  // Mend Community プランの 3GB 制限で kernel OOM kill される。
-  // https://github.com/renovatebot/renovate/discussions/40942
-  // "postUpdateOptions": ["pnpmDedupe", "npmDedupe"],
+  // 更新後に lockfile を自動 dedupe (pnpm dedupe / npm dedupe)
+  "postUpdateOptions": ["pnpmDedupe", "npmDedupe"],
 
   // git submodule の ref 更新を追従対象にする (デフォルト false)
   "git-submodules": {


### PR DESCRIPTION
## Summary

PR #737 で削除した `postUpdateOptions` を元に戻す。

## 理由

OOM の根本原因は `pnpm dedupe` ではなく `pnpm install --lockfile-only` 自体（2GB+）だった。dedupe を削除しても Mend-hosted の OOM は解消しなかった。

nozomiishii/dev は self-hosted Renovate（GitHub Actions, 7GB メモリ）に切り替えたため、共有 preset で dedupe を無効化する必要がなくなった。他のリポジトリでは Mend-hosted + dedupe が正常に動作している。

## Test plan

- [x] `renovate-config-validator --strict` 通過
- [ ] configs 等の他リポジトリで Renovate が引き続き正常動作すること

https://claude.ai/code/session_01NNqWLTZhVLTFviHCtZ1r2F