### PR TITLE
fix: rename workflow name to Self-hosted Renovate

### DIFF
--- a/.github/workflows/self-hosted-renovate.yaml
+++ b/.github/workflows/self-hosted-renovate.yaml
@@ -10,7 +10,7 @@
 #
 # 上流で解決されたらこのワークフローを削除し Mend-hosted に戻す。
 
-name: Renovate
+name: Self-hosted Renovate
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

- ワークフローの `name:` を `Renovate` から `Self-hosted Renovate` に修正

https://claude.ai/code/session_0161R5oqf1dSDuFprDdWDJ1S