### PR TITLE
chore: change Renovate schedule from weekly to daily

### DIFF
--- a/.github/workflows/self-hosted-renovate.yaml
+++ b/.github/workflows/self-hosted-renovate.yaml
@@ -14,8 +14,8 @@ name: Self-hosted Renovate
 
 on:
   schedule:
-    # 毎週金曜 05:00 JST (木曜 20:00 UTC)
-    - cron: "0 20 * * 4"
+    # 毎日 05:00 JST (前日 20:00 UTC)
+    - cron: "0 20 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Renovate の実行スケジュールを週1から毎日に変更

## 理由

週1だと PR がコンフリクトしたまま次の実行まで放置される。毎日実行すれば rebase や新規 PR 作成が翌日には処理される。

## Test plan

- [ ] workflow_dispatch で手動実行して正常終了を確認

https://claude.ai/code/session_0161R5oqf1dSDuFprDdWDJ1S