### PR TITLE
chore: group all self-hosted Renovate updates into a single PR

### DIFF
--- a/.github/workflows/self-hosted-renovate.yaml
+++ b/.github/workflows/self-hosted-renovate.yaml
@@ -48,3 +48,6 @@ jobs:
           token: ${{ steps.op-load-secret.outputs.RENOVATE_TOKEN }}
         env:
           RENOVATE_REPOSITORIES: nozomiishii/dev
+          # 全更新を 1 PR にまとめる。個別 PR だと lockfile コンフリクトが連鎖して滞留するため。
+          # 一部パッケージが別グループになる場合はアプローチ 2 (force.packageRules 置換) へ切り替える。
+          RENOVATE_FORCE: '{"groupName":"all dependencies","groupSlug":"all","separateMajorMinor":false}'

--- a/.github/workflows/self-hosted-renovate.yaml
+++ b/.github/workflows/self-hosted-renovate.yaml
@@ -49,5 +49,4 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: nozomiishii/dev
           # 全更新を 1 PR にまとめる。個別 PR だと lockfile コンフリクトが連鎖して滞留するため。
-          # 一部パッケージが別グループになる場合はアプローチ 2 (force.packageRules 置換) へ切り替える。
           RENOVATE_FORCE: '{"groupName":"all dependencies","groupSlug":"all","separateMajorMinor":false}'


### PR DESCRIPTION
## Summary

- Self-hosted Renovate で個別 PR だと 1 つマージするたびに lockfile コンフリクトが連鎖し、残りの PR が滞留していた
- `RENOVATE_FORCE` で全更新を 1 つの PR にまとめることで lockfile コンフリクトを解消
- 一部パッケージが別グループになる場合はアプローチ 2（`force.packageRules` 置換）へ切り替える

## Test plan

- [ ] Self-hosted Renovate を `workflow_dispatch` で手動実行し、1 つの PR にまとまることを確認
- [ ] グルーピングから漏れるパッケージがないか確認

https://claude.ai/code/session_01GGVo6fDXzc3MoFCbUmwUB7