### PR TITLE
feat: group all non-major updates into a single PR

### DIFF
--- a/.github/workflows/self-hosted-renovate.yaml
+++ b/.github/workflows/self-hosted-renovate.yaml
@@ -47,6 +47,5 @@ jobs:
         with:
           token: ${{ steps.op-load-secret.outputs.RENOVATE_TOKEN }}
         env:
+          # メジャー以外の一括グループ化は default.json の all-minor-patch ルールで恒久化済み
           RENOVATE_REPOSITORIES: nozomiishii/dev
-          # 全更新を 1 PR にまとめる。個別 PR だと lockfile コンフリクトが連鎖して滞留するため。
-          RENOVATE_FORCE: '{"groupName":"all dependencies","groupSlug":"all","separateMajorMinor":false}'

--- a/.github/workflows/self-hosted-renovate.yaml
+++ b/.github/workflows/self-hosted-renovate.yaml
@@ -47,5 +47,4 @@ jobs:
         with:
           token: ${{ steps.op-load-secret.outputs.RENOVATE_TOKEN }}
         env:
-          # メジャー以外の一括グループ化は default.json の all-minor-patch ルールで恒久化済み
           RENOVATE_REPOSITORIES: nozomiishii/dev

--- a/default.json
+++ b/default.json
@@ -82,7 +82,8 @@
       "schedule": ["before 9am on Monday"]
     },
 
-    // 関連パッケージのグルーピング (個別 PR 乱立を防ぐ)
+    // 関連パッケージのグルーピング。
+    // minor / patch は末尾の all-minor-patch グループに吸収されるため、実効は major のみ
     {
       "groupName": "figma-export",
       "matchPackageNames": ["/figma-export/"]
@@ -128,13 +129,25 @@
     // 自前 (nozomiishii/*) パッケージは top-level minimumReleaseAge が
     // 課す 3 日待ちを解除して即時取り込みする。
     // git-harvest / pm は scope なしで公開している自前パッケージなので明示列挙。
-    // packageRules は後方のルールほど優先されるので必ず最後に配置
+    // packageRules は後方のルールほど優先されるので他のグループ系ルールより後ろに配置
     // https://docs.renovatebot.com/configuration-options/#packagerules
     {
       "description": "Opt nozomiishii self-managed packages out of the minimumReleaseAge delay",
       "groupName": "nozomiishii",
       "minimumReleaseAge": null,
       "matchPackageNames": ["/nozomiishii/", "git-harvest", "pm"]
+    },
+
+    // メジャー以外 (minor / patch / digest) は全部 1 PR に一括更新する。
+    // 個別 PR だと lockfile コンフリクトが連鎖して滞留するため。
+    // group:allNonMajor 相当。前方の全グループ (storybook / nozomiishii 等) の
+    // groupName を上書きして一括に吸収するため、preset ではなく最後のルールとして定義。
+    // https://docs.renovatebot.com/presets-group/#groupallnonmajor
+    {
+      "description": "Group all non-major updates into a single PR",
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchUpdateTypes": ["digest", "patch", "minor"]
     }
   ],
 

--- a/default.json
+++ b/default.json
@@ -139,7 +139,6 @@
     },
 
     // メジャー以外 (minor / patch / digest) は全部 1 PR に一括更新する。
-    // 個別 PR だと lockfile コンフリクトが連鎖して滞留するため。
     // group:allNonMajor 相当。前方の全グループ (storybook / nozomiishii 等) の
     // groupName を上書きして一括に吸収するため、preset ではなく最後のルールとして定義。
     // https://docs.renovatebot.com/presets-group/#groupallnonmajor


### PR DESCRIPTION
## 概要

self-hosted Renovate の一時対応として `RENOVATE_FORCE` で強制していた「全更新を 1 PR にまとめる」運用が良かったため、メジャー以外の一括更新を shared config に恒久化する。

- [nozomiishii/dev#3003](https://github.com/nozomiishii/dev/pull/3003) で試した一括更新の運用を全 repo に展開
- 個別 PR だと lockfile コンフリクトが連鎖して滞留する問題も解消される

## 変更内容

### default.json

`packageRules` の末尾に [group:allNonMajor](https://docs.renovatebot.com/presets-group/#groupallnonmajor) 相当のルールを追加。

- minor / patch / digest は全部 `all non-major dependencies` の 1 PR に一括更新
- major は従来どおり個別 PR (`separateMultipleMajor` / `automerge: false` は維持)
- 前方のグループ (storybook / nozomiishii 等) の `groupName` を上書きして吸収するため、preset の extends ではなく最後の packageRule として定義
- nozomiishii ルールの `minimumReleaseAge: null` はプロパティ単位のマージで維持される

### self-hosted-renovate.yaml

一時対応の `RENOVATE_FORCE` を撤去。

- 一括グループ化は default.json 側に移行
- 従来の force 設定は `separateMajorMinor: false` で major まで 1 PR に巻き込んでいたが、今後 major は個別 PR に分離される

## 検証

- `pnpm format` ✅
- `pnpm validate` (renovate-config-validator --strict) ✅