### PR TITLE
chore: cap renovate node memory and pause self-hosted schedule

### DIFF
--- a/.github/workflows/self-hosted-renovate.yaml
+++ b/.github/workflows/self-hosted-renovate.yaml
@@ -1,23 +1,22 @@
-# Self-hosted Renovate (Mend Community プランの 3GB メモリ制限で OOM するため)
+# Self-hosted Renovate (Mend-hosted への切り戻しを検証中のため定期実行は停止)
 #
 # pnpm v11 の pnpm install --lockfile-only が 2GB+ のメモリを消費し、
-# Mend-hosted の microVM (3GB) では kernel OOM kill される。
+# Mend-hosted の microVM (3GB) では kernel OOM kill されるため用意したワークフロー。
 # GitHub Actions ランナー (7GB) なら余裕で収まる。
 #
-# Mend 側の対応状況:
+# pnpm 側で修正済み:
+# - https://github.com/pnpm/pnpm/issues/8441 (pnpm v11.15.1 で解消)
+# - https://github.com/pnpm/pnpm/pull/13133
 # - https://github.com/renovatebot/renovate/discussions/40942
-# - https://github.com/pnpm/pnpm/issues/8441
 #
-# 上流で解決されたらこのワークフローを削除し Mend-hosted に戻す。
+# そのため Mend-hosted へ戻せるか検証中。schedule を外して手動実行 (workflow_dispatch) のみ残す。
+# 問題なければこのワークフローごと削除する。
 # 削除時は監視ルーティンも一緒に消す:
 # https://claude.ai/code/routines/trig_01FcwuSkDR2RQBoy2Z9RBi9h
 
 name: Self-hosted Renovate
 
 on:
-  schedule:
-    # 毎日 05:00 JST (前日 20:00 UTC)
-    - cron: "0 20 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/default.json
+++ b/default.json
@@ -75,6 +75,14 @@
     "enabled": true
   },
 
+  // Mend Community の 3GB microVM で Node が上限を突き抜けて kernel OOM kill されるのを防ぐ。
+  // 値は Mend 推奨レンジ (1.5-2.5GB) の上限。
+  // https://docs.renovatebot.com/mend-hosted/faq/
+  // https://github.com/renovatebot/renovate/discussions/40942
+  "toolSettings": {
+    "nodeMaxMemory": 2560
+  },
+
   "packageRules": [
     // renovate 本体の更新は頻度が高いので週 1 に絞る
     {


### PR DESCRIPTION
## 背景

nozomiishii の GitHub アカウントでは Mend-hosted Renovate (Community/Free プラン) を使っているが、developer.mend.io の dashboard で 29 repo 中 16 repo が `Renovate Status: disabled` になっており、`language` / `dance` / `design` は現役なのに一度もジョブが完走していない (repo ページが "There are no jobs in the repository" / "No dependencies detected")。

原因の一つが、Mend Community の 3GB microVM で pnpm が OOM する既知問題。この repo の `.github/workflows/self-hosted-renovate.yaml` は、まさにそれを避けるため 2026-06-24 に追加したもの (対象は `RENOVATE_REPOSITORIES: nozomiishii/dev` の 1 repo のみ)。

その pnpm 側が解決した。

- [pnpm/pnpm#8441](https://github.com/pnpm/pnpm/issues/8441) "pnpm install suddenly reaches heap limit every time." は [pnpm/pnpm#13133](https://github.com/pnpm/pnpm/pull/13133) で 2026-07-19 に close され、**pnpm v11.15.1** に同梱
- 先行して [pnpm/pnpm#12870](https://github.com/pnpm/pnpm/pull/12870) が **v11.11.0** に入り cold-start メモリを v10 水準まで削減
- [renovatebot/renovate discussion #40942](https://github.com/renovatebot/renovate/discussions/40942) で報告者が「pnpm 11.11 / 11.15.1 で kernel OOM が解消した」と報告。ただし `toolSettings.nodeMaxMemory: 2560` は設定したまま維持している

そこで self-hosted を畳んで Mend-hosted に戻せるか検証する。この PR はその第一歩。

## 変更内容

### 1. `default.json` に `toolSettings.nodeMaxMemory` を追加

`toolSettings.nodeMaxMemory` は Node の `--max-old-space-size` 相当の**上限キャップ**。未設定だと Node が container の上限を突き抜けて kernel OOM kill されるため、あえて 3GB より低く絞って先に GC させるのが Mend の推奨 ([Mend-hosted FAQ](https://docs.renovatebot.com/mend-hosted/faq/) が 1.5〜2.5GB を推奨)。値は推奨レンジの上限かつ discussion #40942 で実績のある **2560** (MiB) を使う。

### 2. `self-hosted-renovate.yaml` を事実上停止

`on:` から `schedule` (`cron: "0 20 * * *"`) を外し、`workflow_dispatch` だけ残した。手動実行はできるが定期実行はされない。冒頭のコメントも現状 (pnpm 側修正済み → Mend-hosted への切り戻しを検証中) に合わせて書き換えた。

`RENOVATE_REPOSITORIES` は変更していない。監視 routine の削除メモは、まだ検証中なのでそのまま残している。

## 補足: `nodeMaxMemory` の型

依頼では `"2560"` (文字列) だったが、Renovate の option 定義は `type: "integer"` で、`renovate-config-validator --strict` が次のエラーで落ちた。

```
Configuration option `toolSettings.nodeMaxMemory` should be an integer. Found: "2560" (string).
```

そのため数値の `2560` にした。値そのものは変えていない。

## 切り戻し

`self-hosted-renovate.yaml` の `on:` に `schedule` ブロックを戻すだけ。

```yaml
on:
  schedule:
    # 毎日 05:00 JST (前日 20:00 UTC)
    - cron: "0 20 * * *"
  workflow_dispatch:
```

## 検証

```
$ pnpm validate
 INFO: Validating default.json as global config
 INFO: Config validated successfully against 1 file(s)

$ pnpm format
Checking formatting...
All matched files use Prettier code style!
```
