### PR TITLE
chore: skip digest pinning for custom regex manager docker deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -134,6 +134,16 @@
       "overridePackageName": "opentofu/opentofu"
     },
 
+    // `# renovate:` コメント追跡の docker 依存 (1password/op 等) は digest を書く場所がなく、
+    // docker:pinDigests が毎回 update-failure になるため digest pin だけ外す。
+    // 経緯: docs/decisions/regex custom manager の docker 依存は digest pin しない.md
+    {
+      "description": "Skip digest pinning for custom regex manager deps: no place to write a digest",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "pinDigests": false
+    },
+
     // 自前 (nozomiishii/*) パッケージは top-level minimumReleaseAge が
     // 課す 3 日待ちを解除して即時取り込みする。
     // git-harvest / pm は scope なしで公開している自前パッケージなので明示列挙。

--- a/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
+++ b/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
@@ -9,7 +9,31 @@ zizmor の [unpinned-tools audit](https://docs.zizmor.sh/audits/#unpinned-tools)
 
 extends している `config:best-practices` は [`docker:pinDigests`](https://docs.renovatebot.com/presets-docker/#dockerpindigests) を含む。マッチ条件は manager ではなく datasource なので、この custom manager の依存にも `pinDigests: true` が付く。
 
-digest pin は image 参照のタグの後ろにハッシュを書き足す更新で、Dockerfile の `FROM node:24.19.0` を `FROM node:24.19.0@sha256:…` に書き換える形で成立する。workflow の `version: "2.38.1"` は action の入力パラメータであって image 参照ではなく、digest を書き足す文法上の場所がない。Renovate は「version 据え置き + digest 追記」の差分を作れず、ファイルが 1 文字も変わらないまま自身の検証に落ちる。これが nozomiishii/dev の Dependency Dashboard に Errored の pin 1password/op docker tag として毎回現れていた update-failure の正体。
+digest pin は image 参照のタグの後ろにハッシュを書き足す更新。Dockerfile の image 参照には digest の置き場が文法として存在するので成立する。
+
+```dockerfile
+# before
+FROM node:24.19.0
+# after: タグの後ろに digest を書き足す
+FROM node:24.19.0@sha256:8dca8a3b…
+```
+
+追従対象の workflow はこう書いている。`version:` は action の入力パラメータであって image 参照ではなく、action はこの文字列で 1Password CDN から CLI バイナリをダウンロードする。
+
+```yaml
+- uses: 1password/load-secrets-action@e544b780… # action 本体の digest pin は uses: 側で済んでいる
+  with:
+    # renovate: datasource=docker depName=1password/op versioning=semver
+    version: "2.38.1" # 問題の依存はここ
+```
+
+digest pin を成立させるにはこう書くしかないが、action はこの文字列をバージョン番号として解釈できず壊れる。digest を書き足す文法上の場所がない。
+
+```yaml
+version: "2.38.1@sha256:9c1824a…"
+```
+
+Renovate は「version 据え置き + digest 追記」の差分を作れず、ファイルが 1 文字も変わらないまま自身の検証に落ちる。これが nozomiishii/dev の Dependency Dashboard に Errored の pin 1password/op docker tag として毎回現れていた update-failure の正体。
 
 仮に digest を書けたとしても、pin されるのは Docker Hub のイメージのハッシュで、実行時にダウンロードされるのは 1Password CDN の CLI バイナリ。別物なので守れるものがない。
 

--- a/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
+++ b/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
@@ -1,0 +1,27 @@
+# regex custom manager の docker 依存は digest pin しない
+
+Status: accepted
+Date: 2026-08-12
+
+## Context — 判断を迫られた状況
+
+zizmor の [unpinned-tools audit](https://docs.zizmor.sh/audits/#unpinned-tools) は `1password/load-secrets-action` の `version:` 入力が未指定か `latest` だと検出する。リテラル pin が必要になり、[#679](https://github.com/nozomiishii/renovate/pull/679) で `# renovate:` コメント + regex custom manager による追従を追加した。op CLI は npm にも GitHub releases にも存在しないため、clean semver タグを持つ Docker Hub の `1password/op` イメージを version oracle として `datasource=docker` で追従している。
+
+extends している `config:best-practices` は [`docker:pinDigests`](https://docs.renovatebot.com/presets-docker/#dockerpindigests) を含む。マッチ条件は manager ではなく datasource なので、この custom manager の依存にも `pinDigests: true` が付く。
+
+digest pin は image 参照のタグの後ろにハッシュを書き足す更新で、Dockerfile の `FROM node:24.19.0` を `FROM node:24.19.0@sha256:…` に書き換える形で成立する。workflow の `version: "2.38.1"` は action の入力パラメータであって image 参照ではなく、digest を書き足す文法上の場所がない。Renovate は「version 据え置き + digest 追記」の差分を作れず、ファイルが 1 文字も変わらないまま自身の検証に落ちる。これが nozomiishii/dev の Dependency Dashboard に Errored の pin 1password/op docker tag として毎回現れていた update-failure の正体。
+
+仮に digest を書けたとしても、pin されるのは Docker Hub のイメージのハッシュで、実行時にダウンロードされるのは 1Password CDN の CLI バイナリ。別物なので守れるものがない。
+
+## Decision — 決めたこと
+
+- packageRules に `matchManagers: ["custom.regex"]` と `matchDatasources: ["docker"]` の組で `pinDigests: false` を追加する
+- datasource は docker のまま維持する。バージョン取得元として他に選択肢がない
+- 無効化するのは digest pin だけ。バージョン文字列の追従は今までどおり動かす
+
+## Consequences — 決定がもたらすもの
+
+- dev の Dependency Dashboard から Errored が消える
+- Dockerfile など docker 系 manager の digest pin と、lefthook の bunx 追従 (custom.regex × npm) には影響しない
+- 同じ `# renovate:` 書式で docker datasource の依存を増やしても再発しない
+- zizmor unpinned-tools が求めるリテラル pin は満たしたまま


### PR DESCRIPTION
## 背景

nozomiishii/dev の Dependency Dashboard に Errored の「pin 1password/op docker tag to 9c1824a」が残り続け、Mend-hosted の実行ログに `⚠️ WARN: Error updating branch: update failure` が毎回出ていた。PR もブランチも一度も作られない空振りが恒常化していた。

原因は preset 同士の衝突:

- zizmor の [unpinned-tools audit](https://docs.zizmor.sh/audits/#unpinned-tools) 対応として [#679](https://github.com/nozomiishii/renovate/pull/679) で入れた `# renovate:` コメント方式の custom manager が、`1password/load-secrets-action` の `version:` 入力を Docker Hub の `1password/op` タグを version oracle にして `datasource=docker` で追従している
- extends している `config:best-practices` は [`docker:pinDigests`](https://docs.renovatebot.com/presets-docker/#dockerpindigests) を含み、マッチ条件が manager ではなく datasource なので、この custom manager の依存にも `pinDigests: true` が付く
- `version: "2.38.1"` は action の入力パラメータであって image 参照ではなく、`FROM node:24@sha256:…` のような digest を書き足す文法上の場所がない。Renovate は「version 据え置き + digest 追記」の差分を作れず、ファイルが 1 文字も変わらないまま自身の検証に落ちて update-failure になる
- 仮に digest を書けても、pin されるのは Docker Hub イメージのハッシュで、実行時にダウンロードされるのは 1Password CDN の CLI バイナリ。別物なので守れるものがない

## 変更内容

- `default.json` の packageRules に `matchManagers: ["custom.regex"]` × `matchDatasources: ["docker"]` で `pinDigests: false` を追加
- 経緯の詳細を ADR `docs/decisions/regex custom manager の docker 依存は digest pin しない.md` として新規作成 (この repo 初の `docs/`)

## 影響範囲

- 無効化されるのは「custom regex 経由かつ docker datasource」の digest pin だけ。バージョン文字列の追従は今までどおり動く
- Dockerfile 等の docker 系 manager の digest pin、lefthook の bunx 追従 (custom.regex × npm) には影響しない
- マージ後の次回 run から pin 試行自体が消え、dev の Dashboard の Errored も消える。pin 用ブランチは一度も作られていないので後始末は不要

## 検証

```
$ pnpm validate
 INFO: Config validated successfully against 1 file(s)

$ pnpm format
All matched files use Prettier code style!
```
