### PR TITLE
fix: migrate markdownlint config to ESM for config package v2

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,1 +1,0 @@
-module.exports = require("@nozomiishii/markdownlint-cli2-config");

--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -1,1 +1,1 @@
-export { default } from '@nozomiishii/markdownlint-cli2-config';
+export { default } from "@nozomiishii/markdownlint-cli2-config";

--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -1,0 +1,1 @@
+export { default } from '@nozomiishii/markdownlint-cli2-config';

--- a/README.ja.md
+++ b/README.ja.md
@@ -45,7 +45,7 @@ echo '{ "extends": ["github>nozomiishii/renovate"] }' > .github/renovate.json
 
 vulnerabilityAlertsを使えるようにgithubのレポジトリを設定する
 
-- https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+- <https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts>
 
 ```bash
 gh repo list \

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ echo '{ "extends": ["github>nozomiishii/renovate"] }' > .github/renovate.json
 
 Configure your GitHub repository to enable vulnerabilityAlerts.
 
-- https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+- <https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts>
 
 ```bash
 gh repo list \


### PR DESCRIPTION
## 概要

`@nozomiishii/markdownlint-cli2-config` v2 (#808 で導入) が ESM 化されたことにより、CJS 形式の `.markdownlint-cli2.cjs` (`module.exports = require(...)`) では `{ __esModule, default }` の namespace object が返ってしまい、markdownlint-cli2 が config を読めず素の既定値 (MD013 line-length 80 など) で lint されていました。

## 変更内容

- `.markdownlint-cli2.cjs` を削除
- `.markdownlint-cli2.mjs` を新規作成 (package 同梱の init スクリプト `bin/cli.sh` が生成するのと同一の形式)

  ```js
  export { default } from '@nozomiishii/markdownlint-cli2-config';
  ```

- config が有効になったことで新たに検出された MD034 (bare URL) を `--fix` で修正 (`README.md` / `README.ja.md`)

## 検証

repo root で以下を実行:

```bash
node_modules/.pnpm/node_modules/.bin/markdownlint-cli2 "**/*.md" "#node_modules"
```

- Finding 行に config 由来のカスタム ignore (`!**/submodules !LICENSE` など) が反映されている
- MD013 が報告されない (config の `MD013: false` が有効)
- 結果: **0 issues / exit 0**

## 補足

同じ `.cjs` パターンを使っている他 repo (dev / dance / design / language 等) にも同件がある可能性があります。この PR では renovate repo のみ対応しています。