### PR TITLE
fix: pin typescript to version 6

### DIFF
--- a/default.json
+++ b/default.json
@@ -105,6 +105,14 @@
       "matchPackageNames": ["/textlint/"]
     },
 
+    // TypeScript 7 の Compiler API に typescript-eslint が対応するまで 6.x に固定する。
+    // https://github.com/typescript-eslint/typescript-eslint/issues/10940
+    {
+      "description": "Keep TypeScript on 6.x until typescript-eslint supports TypeScript 7",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "6.x"
+    },
+
     // download / upload は片側だけ上がると CI が壊れがちなので一緒に
     {
       "matchPackageNames": ["actions/download-artifact", "actions/upload-artifact"],


### PR DESCRIPTION
## 概要

- 共有 Renovate preset で `typescript` の更新先を 6.x に制限
- TypeScript 7 対応の上流 Issue を設定コメントに記載

## 背景

TypeScript 7 は、typed lint に必要な Compiler API を現時点で typescript-eslint が利用できません。対応状況は https://github.com/typescript-eslint/typescript-eslint/issues/10940 で追跡されています。

この制約を共有 preset に置き、preset を利用するリポジトリで TypeScript 7 へ自動更新されないようにします。

## 影響

TypeScript は 6.x 内では更新されますが、上流対応が完了して制約を外すまで 7.x には更新されません。

## 検証

- `pnpm validate`
- `pnpm format`
- `git diff --check`
- pre-commit hook