### PR TITLE
chore: link upstream watch issue

### DIFF
--- a/default.json
+++ b/default.json
@@ -107,6 +107,7 @@
 
     // TypeScript 7 の Compiler API に typescript-eslint が対応するまで 6.x に固定する。
     // https://github.com/typescript-eslint/typescript-eslint/issues/10940
+    // https://github.com/nozomiishii/renovate/issues/815
     {
       "description": "Keep TypeScript on 6.x until typescript-eslint supports TypeScript 7",
       "matchPackageNames": ["typescript"],


### PR DESCRIPTION
## 概要

- TypeScript 6.x 制約の設定コメントにローカル追跡 Issue を追加

## 背景

TypeScript 7 対応の上流 Issue を購読し、解消後の制約撤去を忘れないように追跡 Issue を作成しました。

- 上流: https://github.com/typescript-eslint/typescript-eslint/issues/10940
- ローカル追跡: https://github.com/nozomiishii/renovate/issues/815
- 元の対応: https://github.com/nozomiishii/renovate/pull/814

## 検証

- `pnpm validate`
- `pnpm format`
- `git diff --check`