### PR TITLE
feat: group opentofu major updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -142,6 +142,16 @@
       "overridePackageName": "opentofu/opentofu"
     },
 
+    // OpenTofu の major は mise.toml (mise manager) と required_version (terraform manager) が
+    // manager ごとに別 PR に分かれるため 1 PR にまとめる。非メジャーは末尾の all-minor-patch が吸収する。
+    // 経緯: infra の docs/decisions/OpenTofu の版は mise.toml と required_version の二重ピンにする.md
+    {
+      "description": "Group opentofu major updates across managers into a single PR",
+      "groupName": "opentofu",
+      "matchPackageNames": ["opentofu/opentofu"],
+      "matchUpdateTypes": ["major"]
+    },
+
     // `# renovate:` コメント追跡の docker 依存 (1password/op 等) は digest を書く場所がなく、
     // docker:pinDigests が毎回 update-failure になるため digest pin だけ外す。
     // 経緯: docs/decisions/regex custom manager の docker 依存は digest pin しない.md


### PR DESCRIPTION
## 概要

nozomiishii/infra#179 で OpenTofu の版が mise.toml と required_version の二重ピンになる。opentofu の **major** 更新は mise manager (mise.toml) と terraform manager (required_version) で別 PR に分かれてしまうため、`opentofu/opentofu` の major を 1 PR にグループ化するルールを追加する。

- 非メジャーは既存の末尾ルール (all-minor-patch) が両 manager 分を吸収するので対象外 (`matchUpdateTypes: ["major"]` のみ)
- 配置は required_version の overridePackageName ルール直後。後方の all-minor-patch ルールとは update type が重ならず干渉しない

## マージ順

**infra#179 より先にこちらをマージするのが望ましい** (後でも壊れないが、間に opentofu の major が来ると PR が分裂する)。

## 検証

- `pnpm validate` (renovate-config-validator --strict) パス
- `pnpm format` (prettier --check) パス