### PR TITLE
feat: track devEngines.packageManager version

### DIFF
--- a/default.json
+++ b/default.json
@@ -204,22 +204,23 @@
     // npm manager のネイティブ対応 (runtime / packageManager 一括) が来たら以下 3 件まとめて撤去:
     // https://github.com/renovatebot/renovate/pull/43369
     // https://github.com/renovatebot/renovate/issues/38067
+    // devEngines は配列形式も取れるため、name は filter (`[name = 'node']`) で選ぶ。
     {
       "description": "Track devEngines.runtime Node.js version in package.json.",
       "customType": "jsonata",
       "fileFormat": "json",
-      "managerFilePatterns": ["/package.json/"],
+      "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
-        "$exists(devEngines.runtime) and devEngines.runtime.name = 'node' ? [{\"depName\": \"node\", \"currentValue\": devEngines.runtime.version, \"datasource\": \"node-version\", \"versioning\": \"node\"}] : []"
+        "$exists(devEngines.runtime[name = 'node'].version) ? [{\"depName\": \"node\", \"currentValue\": devEngines.runtime[name = 'node'].version, \"datasource\": \"node-version\", \"versioning\": \"node\"}] : []"
       ]
     },
     {
       "description": "Track devEngines.runtime Bun version in package.json.",
       "customType": "jsonata",
       "fileFormat": "json",
-      "managerFilePatterns": ["/package.json/"],
+      "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
-        "$exists(devEngines.runtime) and devEngines.runtime.name = 'bun' ? [{\"depName\": \"bun\", \"currentValue\": devEngines.runtime.version, \"datasource\": \"github-releases\", \"packageName\": \"oven-sh/bun\", \"extractVersion\": \"^bun-v(?<version>.+)$\"}] : []"
+        "$exists(devEngines.runtime[name = 'bun'].version) ? [{\"depName\": \"bun\", \"currentValue\": devEngines.runtime[name = 'bun'].version, \"datasource\": \"github-releases\", \"packageName\": \"oven-sh/bun\", \"extractVersion\": \"^bun-v(?<version>.+)$\"}] : []"
       ]
     },
     // packageManager フィールドと食い違うと devEngines 側が勝つため、
@@ -228,7 +229,7 @@
       "description": "Track devEngines.packageManager pnpm version in package.json.",
       "customType": "jsonata",
       "fileFormat": "json",
-      "managerFilePatterns": ["/package.json/"],
+      "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
         "$exists(devEngines.packageManager[name = 'pnpm'].version) ? [{\"depName\": \"pnpm\", \"currentValue\": devEngines.packageManager[name = 'pnpm'].version, \"datasource\": \"npm\"}] : []"
       ]

--- a/default.json
+++ b/default.json
@@ -200,8 +200,8 @@
         "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+[A-Za-z0-9_-]*[Vv][Ee][Rr][Ss][Ii][Oo][Nn]:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
       ]
     },
-    // devEngines.runtime のバージョンを追従。
-    // npm manager のネイティブ対応が来たら撤去:
+    // devEngines のバージョンを追従。
+    // npm manager のネイティブ対応 (runtime / packageManager 一括) が来たら以下 3 件まとめて撤去:
     // https://github.com/renovatebot/renovate/pull/43369
     // https://github.com/renovatebot/renovate/issues/38067
     {
@@ -220,6 +220,17 @@
       "managerFilePatterns": ["/package.json/"],
       "matchStrings": [
         "$exists(devEngines.runtime) and devEngines.runtime.name = 'bun' ? [{\"depName\": \"bun\", \"currentValue\": devEngines.runtime.version, \"datasource\": \"github-releases\", \"packageName\": \"oven-sh/bun\", \"extractVersion\": \"^bun-v(?<version>.+)$\"}] : []"
+      ]
+    },
+    // packageManager フィールドと食い違うと devEngines 側が勝つため、
+    // 追従しないと pnpm が古い版に固定される。
+    {
+      "description": "Track devEngines.packageManager pnpm version in package.json.",
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/package.json/"],
+      "matchStrings": [
+        "$exists(devEngines.packageManager[name = 'pnpm'].version) ? [{\"depName\": \"pnpm\", \"currentValue\": devEngines.packageManager[name = 'pnpm'].version, \"datasource\": \"npm\"}] : []"
       ]
     },
     // lefthook.yaml の `bunx <pkg>@<version>` を追従。


### PR DESCRIPTION
## 概要

共有 preset に `devEngines.packageManager.version` を追従する customManager を追加する。

## 背景

corepack 廃止に伴い、誤パッケージマネージャーガードを package.json の宣言に移行した (https://github.com/nozomiishii/dotfiles/pull/1561 / この repo は #822)。broadcast した構成は version を持たない:

```json
"packageManager": "pnpm@11.21.0",
"devEngines": {
  "packageManager": { "name": "pnpm", "onFail": "error" }
}
```

この状態では pnpm が実行のたびに警告を出す:

```
[WARN] Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored
```

pnpm ソース (`config/reader/src/index.ts` の `getPackageManagerConflictWarning`) の挙動:

- 警告は 2 つのフィールドが食い違うときだけ出る。name / version / integrity hash がすべて一致すれば出ない (https://github.com/pnpm/pnpm/pull/12287)
- 競合時は devEngines が勝ち、`packageManager` は無視される

つまり devEngines 側に version を書けば警告は消えるが、その version が古いまま取り残されると pnpm が古い版に固定される。Renovate 標準の npm manager は `packageManager` しか dep として抽出しない (44.27.0 時点では `devEngines.packageManager` は `hasPackageManager` 判定に使うだけ) ため、追従には customManager が要る。

なお Renovate 自身も lockfile 更新時に走らせる pnpm の制約として `devEngines.packageManager.version` を読む (`npm/post-update/utils.ts`)。放置すると Renovate 側の実行 pnpm まで古い版に張り付く。

devEngines に完全固定の version を書く方針は pnpm リード zkochan も支持している (https://github.com/pnpm/pnpm/issues/12797)。

## 変更内容

`customManagers` に jsonata エントリを 1 つ追加。既存の `devEngines.runtime` 用エントリと同じブロック (ネイティブ対応が来たら 3 件まとめて撤去) に置いた。

```
$exists(devEngines.packageManager[name = 'pnpm'].version) ? [{"depName": "pnpm", "currentValue": devEngines.packageManager[name = 'pnpm'].version, "datasource": "npm"}] : []
```

- datasource は `npm`、depName は `pnpm` 決め打ち。yarn berry は npm 上の `yarn` パッケージが 1.x で解決先が変わるため、既存 runtime エントリと同様に name ごとに定義する方針
- `devEngines.packageManager` は単一オブジェクトと配列の両形式を取れるので、`.name = 'pnpm'` ではなく filter (`[name = 'pnpm']`) で選ぶ。前者は 2 要素以上の配列で jsonata のシーケンス比較になり、エラーも警告もなく取りこぼす
- `$exists(...)` で guard。version を書いていない現状の全 repo では何も抽出しないので、マージしても既存挙動は変わらない

## 検証

- `renovate-config-validator --strict default.json` → pass
- jsonata 式の単体評価: 単一オブジェクト / 1 要素配列 / 2 要素配列 (npm 先頭・pnpm 先頭とも) → 抽出。version なし・devEngines なし・runtime のみ・yarn のみ → 空配列
- `renovate --platform=local --dry-run=full` で模擬 repo を抽出し、`packageManager` 由来の pnpm と `devEngines.packageManager` 由来の pnpm が同一ブランチ `renovate/all-minor-patch` に入ることを確認。メジャー時も両者は depName / branchTopic が同じ (`renovate/pnpm-<major>.x`) で同一 PR になる
- ファイル書き換えを Renovate 44.27.0 の実コード (`doAutoReplace` + npm manager の `updateDependency`) を直接呼んで実測。単一オブジェクト / 配列 / 複数行整形 × (jsonata 先行・npm 先行) の 6 通りすべてで `packageManager` と `devEngines` 双方が正しく更新され、配列の場合も pnpm 要素だけが更新される
  - custom manager は `updateDependency` を持たず auto-replace 任せで、`replaceString` 未指定時は `currentValue` の最初の出現 (= `packageManager` フィールド側) を掴む。ただし `confirmIfDepUpdated` が再抽出で誤爆を検知して巻き戻し、次の出現を探し直すため実害なし

## 既知の制約 (この PR では対応しない)

- **integrity hash 付き version** (`11.21.0+sha512...`) を書くとハッシュごと置換されて消える。corepack 廃止でハッシュは書かない方針のため実害なし
- **既存の devEngines.runtime 2 件も配列形式を取りこぼす**、および 3 件の `managerFilePatterns: ["/package.json/"]` が未アンカー正規表現 (`package.json.tmpl` 等にもマッチしうる)。既存の挙動なので別 PR (#825) で扱う

## 展開順序

この PR をマージした後に、各 repo へ `devEngines.packageManager.version` を追記する。逆順だと Renovate が `packageManager` だけ bump し、devEngines 側の古い版に固定される。
