### PR TITLE
fix: match array form devEngines and anchor package.json patterns

### DIFF
--- a/default.json
+++ b/default.json
@@ -204,22 +204,23 @@
     // npm manager のネイティブ対応 (runtime / packageManager 一括) が来たら以下 3 件まとめて撤去:
     // https://github.com/renovatebot/renovate/pull/43369
     // https://github.com/renovatebot/renovate/issues/38067
+    // devEngines は配列形式も取れるため、name は filter (`[name = 'node']`) で選ぶ。
     {
       "description": "Track devEngines.runtime Node.js version in package.json.",
       "customType": "jsonata",
       "fileFormat": "json",
-      "managerFilePatterns": ["/package.json/"],
+      "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
-        "$exists(devEngines.runtime) and devEngines.runtime.name = 'node' ? [{\"depName\": \"node\", \"currentValue\": devEngines.runtime.version, \"datasource\": \"node-version\", \"versioning\": \"node\"}] : []"
+        "$exists(devEngines.runtime[name = 'node'].version) ? [{\"depName\": \"node\", \"currentValue\": devEngines.runtime[name = 'node'].version, \"datasource\": \"node-version\", \"versioning\": \"node\"}] : []"
       ]
     },
     {
       "description": "Track devEngines.runtime Bun version in package.json.",
       "customType": "jsonata",
       "fileFormat": "json",
-      "managerFilePatterns": ["/package.json/"],
+      "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
-        "$exists(devEngines.runtime) and devEngines.runtime.name = 'bun' ? [{\"depName\": \"bun\", \"currentValue\": devEngines.runtime.version, \"datasource\": \"github-releases\", \"packageName\": \"oven-sh/bun\", \"extractVersion\": \"^bun-v(?<version>.+)$\"}] : []"
+        "$exists(devEngines.runtime[name = 'bun'].version) ? [{\"depName\": \"bun\", \"currentValue\": devEngines.runtime[name = 'bun'].version, \"datasource\": \"github-releases\", \"packageName\": \"oven-sh/bun\", \"extractVersion\": \"^bun-v(?<version>.+)$\"}] : []"
       ]
     },
     // packageManager フィールドと食い違うと devEngines 側が勝つため、
@@ -228,7 +229,7 @@
       "description": "Track devEngines.packageManager pnpm version in package.json.",
       "customType": "jsonata",
       "fileFormat": "json",
-      "managerFilePatterns": ["/package.json/"],
+      "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
         "$exists(devEngines.packageManager[name = 'pnpm'].version) ? [{\"depName\": \"pnpm\", \"currentValue\": devEngines.packageManager[name = 'pnpm'].version, \"datasource\": \"npm\"}] : []"
       ]


### PR DESCRIPTION
## 概要

devEngines を追従する 3 件の customManager の欠陥を直す。#824 に stack している (base は `feat/track-dev-engines-package-manager`)。

## 背景

#824 のレビューで、既存の `devEngines.runtime` エントリ (node / bun) にも同じ欠陥があることが分かった。

### 1. 配列形式を取りこぼす

`devEngines.runtime` / `devEngines.packageManager` は単一オブジェクトと配列の両形式を取れる ([Node の devEngines 仕様](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines)、Renovate 自身も `npm/schema.ts` で `DevEngineDependency.or(z.array(DevEngineDependency))` として扱う)。

現行の `devEngines.runtime.name = 'node'` は、2 要素以上の配列に対して jsonata のシーケンス比較 (`["bun","node"] = "node"`) になり `false` に落ちる。エラーも警告も出ず、**追従しているつもりで追従していない**状態になる。

### 2. version 未記載の repo で currentValue なしの dep を作る

現行の guard は `$exists(devEngines.runtime)` までしか見ていないため、`version` を書いていない repo で `{"depName": "node", "datasource": "node-version"}` (currentValue なし) を抽出する。

### 3. managerFilePatterns が未アンカー正規表現

`"/package.json/"` は `.` が任意文字でアンカーもないため、`package.json` 以外に `some-package.json.bak` / `my-package.jsonc` / `templates/package.json.hbs` / `packageXjson` などにもマッチする。同じ preset 内の他の customManager は `/(^|/)lefthook\.ya?ml$/` のようにアンカー済みで、devEngines の 3 件だけが規約から外れていた。

## 変更内容

- 3 件とも `.name = '<name>'` を filter (`[name = '<name>']`) に変更。配列・単一オブジェクトの両方に効く
- `$exists(...)` を `.version` まで伸ばして guard
- `managerFilePatterns` を `["/(^|/)package\\.json$/"]` に

## 検証

- `renovate-config-validator --strict default.json` → pass
- jsonata 式の単体評価 (node の例)。`bun のみ` / `version なし` / `devEngines なし` / `packageManager のみ` は現行・修正後とも空配列:

| 入力 | 現行 | 修正後 |
| --- | --- | --- |
| 単一オブジェクト | 抽出 | 抽出 |
| 1 要素配列 | 抽出 | 抽出 |
| 配列 (node + bun) | **空** | 抽出 |
| 配列 (bun + node) | **空** | 抽出 |
| version 未記載 | **currentValue なしで抽出** | 空 |

- `managerFilePatterns` を Renovate の `matchRegexOrGlobList` で実測。`package.json` / `packages/ui/package.json` / `apps/web/package.json` はマッチ、`some-package.json.bak` / `package.json5` / `my-package.jsonc` / `templates/package.json.hbs` / `docs/package-json.md` / `packageXjson` / `tools/package_json.txt` は非マッチ (現行は `package-lock.json` 以外すべてマッチしていた)
- `renovate --platform=local --dry-run=extract` を配列形式の package.json (`runtime: [bun, node]` / `packageManager: [npm, pnpm]`) に対して実行:
  - main の preset → jsonata manager の抽出 **0 件**
  - このブランチ → node / bun / pnpm の **3 件**を抽出
