### PR TITLE
chore: make the docs readable at a glance

### DIFF
--- a/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
+++ b/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
@@ -1,9 +1,11 @@
+---
+status: accepted
+date: 2026-08-12
+---
+
 # regex custom manager の docker 依存は digest pin しない
 
-Status: accepted
-Date: 2026-08-12
-
-## Context — 判断を迫られた状況
+## 背景と課題
 
 `1password/load-secrets-action` の `version:` を Renovate に追従させたら、nozomiishii/dev で update-failure が毎回出るようになった。
 
@@ -45,23 +47,39 @@ FROM node:24.19.0@sha256:8dca8a3b…
     version: "2.38.1" # 問題の依存はここ
 ```
 
-digest pin を成立させるにはこう書くしかないが、action はこの文字列をバージョン番号として解釈できず壊れる。
+## 検討した選択肢
 
-```yaml
-version: "2.38.1@sha256:9c1824a…"
-```
+- `version:` にハッシュを書き足す: digest pin を成立させるにはこう書くしかないが、action はこの文字列をバージョン番号として解釈できず壊れる
 
-仮に digest を書けたとしても、pin されるのは Docker Hub のイメージのハッシュで、実行時にダウンロードされるのは 1Password CDN の CLI バイナリ。別物なので守れるものがない。
+  ```yaml
+  version: "2.38.1@sha256:9c1824a…"
+  ```
 
-## Decision — 決めたこと
+  仮に digest を書けたとしても、pin されるのは Docker Hub のイメージのハッシュで、実行時にダウンロードされるのは 1Password CDN の CLI バイナリ。別物なので守れるものがない
+
+- datasource を docker 以外にする: バージョン取得元として他に選択肢がない
+
+- `custom.regex` manager × docker datasource の組だけ `pinDigests: false` にする: 成立しない digest pin だけを外せる
+
+## 決定
 
 - packageRules に `matchManagers: ["custom.regex"]` と `matchDatasources: ["docker"]` の組で `pinDigests: false` を追加する
-- datasource は docker のまま維持する。バージョン取得元として他に選択肢がない
+- datasource は docker のまま維持する
 - 無効化するのは digest pin だけ。バージョン文字列の追従は今までどおり動かす
 
-## Consequences — 決定がもたらすもの
+## 結果
+
+### 良くなったこと
 
 - dev の Dependency Dashboard から Errored が消える
 - Dockerfile など docker 系 manager の digest pin と、lefthook の bunx 追従 (custom.regex manager × npm datasource) には影響しない
 - 同じ `# renovate:` 書式で docker datasource の依存を増やしても再発しない
 - zizmor unpinned-tools が求めるリテラル pin は満たしたまま
+
+### 引き受けたコスト
+
+なし
+
+### 保留した論点
+
+なし

--- a/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
+++ b/docs/decisions/regex custom manager の docker 依存は digest pin しない.md
@@ -5,9 +5,27 @@ Date: 2026-08-12
 
 ## Context — 判断を迫られた状況
 
-zizmor の [unpinned-tools audit](https://docs.zizmor.sh/audits/#unpinned-tools) は `1password/load-secrets-action` の `version:` 入力が未指定か `latest` だと検出する。リテラル pin が必要になり、[#679](https://github.com/nozomiishii/renovate/pull/679) で `# renovate:` コメント + regex custom manager による追従を追加した。op CLI は npm にも GitHub releases にも存在しないため、clean semver タグを持つ Docker Hub の `1password/op` イメージを version oracle として `datasource=docker` で追従している。
+`1password/load-secrets-action` の `version:` を Renovate に追従させたら、nozomiishii/dev で update-failure が毎回出るようになった。
 
-extends している `config:best-practices` は [`docker:pinDigests`](https://docs.renovatebot.com/presets-docker/#dockerpindigests) を含む。マッチ条件は manager ではなく datasource なので、この custom manager の依存にも `pinDigests: true` が付く。
+```
+zizmor が version: にリテラル pin を要求する
+  ↓
+op CLI は npm にも GitHub releases にも無い
+  ↓
+clean semver タグを持つ Docker Hub の 1password/op を version oracle にする
+  ↓
+config:best-practices の docker:pinDigests が datasource で一致する
+  ↓
+この custom manager の依存にも pinDigests: true が付く
+  ↓
+version: にはハッシュを書き足す文法上の場所が無い
+  ↓
+Renovate は差分ゼロのまま自身の検証に落ちる
+  ↓
+Dependency Dashboard に Errored の pin 1password/op docker tag が毎回出る
+```
+
+zizmor の [unpinned-tools audit](https://docs.zizmor.sh/audits/#unpinned-tools) は、`1password/load-secrets-action` の `version:` 入力が未指定か `latest` だと検出する。[#679](https://github.com/nozomiishii/renovate/pull/679) で `# renovate:` コメント + regex custom manager による追従を追加した。extends している `config:best-practices` に [`docker:pinDigests`](https://docs.renovatebot.com/presets-docker/#dockerpindigests) が入っている。
 
 digest pin は image 参照のタグの後ろにハッシュを書き足す更新。Dockerfile の image 参照には digest の置き場が文法として存在するので成立する。
 
@@ -27,13 +45,11 @@ FROM node:24.19.0@sha256:8dca8a3b…
     version: "2.38.1" # 問題の依存はここ
 ```
 
-digest pin を成立させるにはこう書くしかないが、action はこの文字列をバージョン番号として解釈できず壊れる。digest を書き足す文法上の場所がない。
+digest pin を成立させるにはこう書くしかないが、action はこの文字列をバージョン番号として解釈できず壊れる。
 
 ```yaml
 version: "2.38.1@sha256:9c1824a…"
 ```
-
-Renovate は「version 据え置き + digest 追記」の差分を作れず、ファイルが 1 文字も変わらないまま自身の検証に落ちる。これが nozomiishii/dev の Dependency Dashboard に Errored の pin 1password/op docker tag として毎回現れていた update-failure の正体。
 
 仮に digest を書けたとしても、pin されるのは Docker Hub のイメージのハッシュで、実行時にダウンロードされるのは 1Password CDN の CLI バイナリ。別物なので守れるものがない。
 
@@ -46,6 +62,6 @@ Renovate は「version 据え置き + digest 追記」の差分を作れず、�
 ## Consequences — 決定がもたらすもの
 
 - dev の Dependency Dashboard から Errored が消える
-- Dockerfile など docker 系 manager の digest pin と、lefthook の bunx 追従 (custom.regex × npm) には影響しない
+- Dockerfile など docker 系 manager の digest pin と、lefthook の bunx 追従 (custom.regex manager × npm datasource) には影響しない
 - 同じ `# renovate:` 書式で docker datasource の依存を増やしても再発しない
 - zizmor unpinned-tools が求めるリテラル pin は満たしたまま


### PR DESCRIPTION
## 概要

docs を、流し読みでも意図が伝わる形に書き直す。nozomiishii/infra で先に適用した方針を横展開したもの。

- 文章で説明していた構造・フロー・対比を図と表にする
- 前提を知らないと読めない並びを組み替える
- 同じ説明が複数箇所にあれば 1 箇所に集約する

書き方の規則は [doc スキルの文章ガイドライン](https://github.com/nozomiishii/dotfiles/blob/main/home/.agents/skills/doc/SKILL.md)。図の形式は「同じ repo の既存 docs に合わせ、前例が無ければ ASCII、ループや合流で線が引けないときだけ Mermaid」に従い、今回は全て ASCII。

技術的な内容・コマンド・パス・URL・数値は変えていない。

## 変更内容

`docs/decisions/regex custom manager の docker 依存は digest pin しない.md`

- Context の冒頭に因果の図を入れた。zizmor の要求から Dependency Dashboard の Errored までを追える
- 図に移した内容を本文から削り、463 字の段落をリンクと検出条件だけに圧縮した
- コードブロックは変更なし

ADR の書式 (`Status:` / `Date:` 行、英語見出し + 和訳の 3 セクション) は維持した。nozomiishii/infra とは別の書式だが、揃えるかは別の判断なので触っていない。
