### PR TITLE
feat: group node and pnpm major updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -153,6 +153,23 @@
       "matchUpdateTypes": ["major"]
     },
 
+    // node と pnpm は mise.toml (mise manager) と devEngines (custom.jsonata) の 2 経路で追従される。
+    // branch 名が depName 由来なので指定なしでも 1 PR に収まるが、片方だけ更新されると
+    // devEngines.packageManager の version 指定で pnpm が起動時に落ちるため groupName で固定する。
+    // 非メジャーは末尾の all-minor-patch が吸収し、separateMultipleMajor で branch は目標 major ごとに分かれる。
+    {
+      "description": "Group node major updates across managers into a single PR",
+      "groupName": "node",
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "description": "Group pnpm major updates across managers into a single PR",
+      "groupName": "pnpm",
+      "matchPackageNames": ["pnpm"],
+      "matchUpdateTypes": ["major"]
+    },
+
     // `# renovate:` コメント追跡の docker 依存 (1password/op 等) は digest を書く場所がなく、
     // docker:pinDigests が毎回 update-failure になるため digest pin だけ外す。
     // 経緯: docs/decisions/regex custom manager の docker 依存は digest pin しない.md


### PR DESCRIPTION
## 変更

`default.json` に node と pnpm の major を 1 PR にまとめる packageRule を 2 件追加した。書き方は既存の `opentofu` ルールに合わせている。

## 依頼の前提は成り立っていない

「major は manager ごとに別 PR に分かれる」は node と pnpm では起きない。branch 名は manager ではなく depName から作られ、3 経路とも depName が `node` / `pnpm` で一致するため、このルールが無くても同じ branch に入る。

mise.toml と package.json (`packageManager` + `devEngines`) を置いた repo に対して、preset だけ入れ替えて `renovate --platform=local --dry-run=full` (44.33.2) で実測した。

| preset | mise manager | npm manager | custom.jsonata |
| --- | --- | --- | --- |
| 変更前 | `renovate/pnpm-11.x` | `renovate/pnpm-11.x` | `renovate/pnpm-11.x` |
| 変更後 | `renovate/major-11-pnpm` | `renovate/major-11-pnpm` | `renovate/major-11-pnpm` |

node も同じで、変更前は `renovate/node-22.x` / `renovate/node-24.x` に mise manager と custom.jsonata が同居していた。

opentofu が分かれたのは depName が `opentofu` (mise) と `hashicorp/terraform` (terraform) で違うからで、node と pnpm には当てはまらない。

このルールの実効は branch 名が `renovate/node-24.x` → `renovate/major-24-node` に変わることだけ。経路が増減しても 1 PR に留まる保証を設定として持つかどうかの判断になる。不要なら close で構わない。

## separateMultipleMajor との関係

グループ化しても major ごとの分離は消えない。`groupSlug` が `major-<newMajor>-<slug>` になるため、node 20 → 22 と 20 → 24 は別 branch のままだった (`renovate/major-22-node` / `renovate/major-24-node`)。

非メジャーは末尾の `all-minor-patch` が吸収する。実測でも mise manager と custom.jsonata の node minor は両方 `renovate/all-minor-patch` に入った。

## mise.lock

Mend-hosted の Renovate は既に mise.lock を追従している。infra で実績があるので、最初の 1 本を待って確認する必要は無い。

- nozomiishii/infra#198 — `mise.toml` / `mise.lock` / `package.json` を同時更新。全 platform の checksum が書き換わっている
- nozomiishii/infra#223 — 同じく `mise.toml` と `mise.lock` を同時更新

mise manager は `allowedUnsafeExecutions` に mise が無い場合、mise 2026.7.12 以上の safe mode で `mise lock` を走らせる。Mend-hosted が入れる mise は jdx/mise の最新 (現在 2026.8.10) なので条件を満たす。lock が取り残された場合は artifactError になり、automerge も止まる。

## 検証

- `pnpm validate` (`renovate-config-validator --strict`) と `pnpm format`
- 上記の dry run 4 本 (node / pnpm × 変更前後)
