### PR TITLE
chore: drop the mise cache runner guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup tools
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## 変更

`jdx/mise-action` の `cache: ${{ runner.environment == 'github-hosted' }}` を削除した。

## 理由

self-hosted runner でキャッシュを切るための分岐だが、この repo の job は全部 `ubuntu-slim` / `ubuntu-latest` のリテラルで、常に true に評価される。`mise-action` v4.2.5 の `cache` の既定値も `true` なので、input ごと消しても挙動は変わらない。

`self-hosted-renovate.yaml` の "self-hosted" は Renovate 本体を自前で回すという意味で、runner は `ubuntu-latest`。runner の話ではない。

## 検証

actionlint がエラー0件で通る。
