### PR TITLE
chore: track _VERSION variables in Dockerfiles

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,7 +19,6 @@
 
     // Dockerfile / Containerfile の `# renovate: ...` annotation 付き `ENV` / `ARG` の `_VERSION` 変数を追従。
     // 公式 preset (https://docs.renovatebot.com/presets-customManagers/#custommanagersdockerfileversions)。
-    // devcontainer 等の Dockerfile 内で版を固定するツール (mise 本体等) で使用。
     "customManagers:dockerfileVersions",
 
     // Makefile / GNUMakefile / *.mk の `# renovate: ...` annotation 付き `_VERSION` 変数を追従。

--- a/default.json
+++ b/default.json
@@ -17,6 +17,11 @@
     // semantic commit の scope 部分を付けない
     ":semanticCommitScopeDisabled",
 
+    // Dockerfile / Containerfile の `# renovate: ...` annotation 付き `ENV` / `ARG` の `_VERSION` 変数を追従。
+    // 公式 preset (https://docs.renovatebot.com/presets-customManagers/#custommanagersdockerfileversions)。
+    // devcontainer 等の Dockerfile 内で版を固定するツール (mise 本体等) で使用。
+    "customManagers:dockerfileVersions",
+
     // Makefile / GNUMakefile / *.mk の `# renovate: ...` annotation 付き `_VERSION` 変数を追従。
     // 公式 preset (https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions)。
     // Docker via Makefile pattern (Terraform エコシステム lint tools 等) で使用。


### PR DESCRIPTION
公式 preset `customManagers:dockerfileVersions` を `extends` に追加した。Dockerfile / Containerfile の `# renovate: ...` コメント直後にある `ENV` / `ARG` の `*_VERSION` を追従する。

## 背景

nozomiishii/dotfiles の `.devcontainer/Dockerfile` で mise 本体の版をこう固定している。

```dockerfile
# renovate: datasource=github-releases depName=jdx/mise
ARG MISE_VERSION=v2026.8.10
```

共有設定に Dockerfile の `_VERSION` を追う manager が無かったため、いまは dotfiles 側の `.github/renovate.json` に repo 固有で足している (https://github.com/nozomiishii/dotfiles/pull/1617)。ただし `bin/cli.sh` は `.github/renovate.json` を `{ "extends": ["github>nozomiishii/renovate"] }` の 1 行で無条件に上書き生成するので、その repo で Renovate を再セットアップすると repo 固有の追加が黙って消える。共有設定に置けば全 repo で持続する。

## 既存設定への影響

- `customManagers` はオプション定義が `mergeable: true` なので、preset 由来の配列と `default.json` 自身の `customManagers` 配列は連結される。既存の 5 件 (workflows の `version:` キー、devEngines の node / bun / pnpm、lefthook の `bunx`) はそのまま残る
- packageRule `matchManagers: ["custom.regex"]` + `matchDatasources: ["docker"]` -> `pinDigests: false` は datasource が docker のものだけに当たる。`MISE_VERSION` は `github-releases` なので影響しない

## 検証

```
$ pnpm validate
 INFO: Validating default.json as global config
 INFO: Config validated successfully against 1 file(s)
```

`npx --yes --package renovate renovate-config-validator default.json` も同じく通る。

## follow-up

マージ後、nozomiishii/dotfiles の `.github/renovate.json` を `{ "extends": ["github>nozomiishii/renovate"] }` の 1 行に戻す。dotfiles PR #1617 で足した repo 固有の `extends` が不要になるため。
